### PR TITLE
Per-engine camera selection + native rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(CORE_ENGINE)
+project(RENDERING_ENGINE)
 
 if (NOT ANDROID_NDK_TOOLCHAIN_INCLUDED)
     message(FATAL_ERROR "-- Toolchain file not included, see https://developer.android.com/ndk/guides/cmake")
@@ -11,7 +11,7 @@ add_library(
         SHARED
         app/src/main/native/cpp/main.cpp
         app/src/main/native/cpp/base_renderer.cpp
-        app/src/main/native/cpp/core_engine.cpp
+        app/src/main/native/cpp/rendering_engine.cpp
         app/src/main/native/cpp/opengl_renderer.cpp
         app/src/main/native/cpp/vulkan_renderer.cpp
         app/src/main/native/cpp/vulkan_wrapper.cpp

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,27 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // libs/shaderc/c++_static/ only ships arm64-v8a binaries.
+        ndk {
+            abiFilters 'arm64-v8a'
+        }
     }
 
     ndkVersion = '25.1.8937393'
+    signingConfigs {
+        // Personal-use convenience: sign release builds with the local debug
+        // keystore so `adb install` works out of the box. Not for distribution.
+        release {
+            storeFile file("${System.getProperty('user.home')}/.android/debug.keystore")
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             ndk {

--- a/app/src/main/java/com/dz/camerafast/CameraActivity.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraActivity.kt
@@ -2,50 +2,35 @@ package com.dz.camerafast
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.content.PermissionChecker
+import com.dz.camerafast.camera.Camera2
+import com.dz.camerafast.camera.CameraData
+import com.dz.camerafast.camera.CameraX
 
 class CameraActivity : ComponentActivity() {
 
-  private val previewEngineList = listOf(
-    CoreEngine(RenderingMode.VULKAN),
-    CoreEngine(RenderingMode.OPEN_GL_ES)
-  )
-  private var cameraModeState = mutableStateOf(CameraMode.NONE)
+  private val vulkanRenderingEngine = RenderingEngine(RenderingMode.VULKAN)
+  private val openGlRenderingEngine = RenderingEngine(RenderingMode.OPEN_GL_ES)
+  private var initialCameraMode = CameraMode.NONE
 
   private val requestPermissionLauncher = registerForActivityResult(
     ActivityResultContracts.RequestPermission()
   ) { isGranted ->
     if (isGranted) {
-      cameraModeState.value = CameraMode.CAMERA_X
+      initialCameraMode = CameraMode.CAMERA_X
     } else {
       finish()
     }
@@ -55,174 +40,129 @@ class CameraActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      val cameraMode by remember {
-        cameraModeState
+      val enginesCamera2 = remember {
+        mutableStateListOf(vulkanRenderingEngine, openGlRenderingEngine)
       }
 
-      var lensFacing by remember {
-        mutableIntStateOf(CameraSelector.LENS_FACING_FRONT)
+      val enginesCameraX = remember {
+        mutableStateListOf(vulkanRenderingEngine, openGlRenderingEngine)
       }
 
-      var displayMode by remember {
-        mutableStateOf(DisplayMode.BOTH)
+      var vulkanCameraData by remember {
+        mutableStateOf(CameraData(initialCameraMode, CameraSelector.LENS_FACING_FRONT))
       }
 
-      var vulkanWeightValue by remember {
-        mutableFloatStateOf(1.0f)
+      var openGlCameraData by remember {
+        mutableStateOf(CameraData(initialCameraMode, CameraSelector.LENS_FACING_FRONT))
       }
 
-      val vulkanWeight by animateFloatAsState(
-        targetValue = vulkanWeightValue,
-        // TODO increase duration and try make dynamic view resize less laggy
-        animationSpec = tween(durationMillis = 0),
-        label = "Vulkan",
-        finishedListener = { endValue ->
-          displayMode = if (endValue == 1.0f) {
-            DisplayMode.BOTH
-          } else {
-            DisplayMode.OPEN_GL_ES
-          }
-        }
-      )
-
-      var openGlWeightValue by remember {
-        mutableFloatStateOf(1.0f)
-      }
-
-      val openGlWeight by animateFloatAsState(
-        targetValue = openGlWeightValue,
-        // TODO increase duration and try make dynamic view resize less laggy
-        animationSpec = tween(durationMillis = 0),
-        label = "OpenGL",
-        finishedListener = { endValue ->
-          displayMode = if (endValue == 1.0f) {
-            DisplayMode.BOTH
-          } else {
-            DisplayMode.VULKAN
-          }
-        }
-      )
-
-      if (cameraMode == CameraMode.CAMERA_X) {
-        CameraX(
-          coreEngines = previewEngineList,
-          lensFacing = lensFacing
-        )
-      }
-
-      if (cameraMode == CameraMode.CAMERA_2) {
-        // Vulkan is not supported yet
-        displayMode = DisplayMode.OPEN_GL_ES
-        Camera2(
-          coreEngines = previewEngineList,
-          lensFacing = lensFacing
-        )
-      }
-
-      Column {
-        Text(
-          text = cameraMode.name,
-          color = Color.White,
-          textAlign = TextAlign.Center,
-          fontSize = 30.sp,
-          modifier = Modifier
-              .background(Color.DarkGray)
-              .fillMaxWidth()
-              .padding(10.dp)
-        )
-        if (displayMode != DisplayMode.VULKAN) {
-          Box(
-            contentAlignment = Alignment.TopStart,
+      if (vulkanCameraData.cameraMode != CameraMode.NONE) {
+        Column {
+          CameraBox(
             modifier = Modifier
-                .weight(openGlWeight)
-                .fillMaxWidth()
-          ) {
-            CameraPreviewView(
-              coreEngine = previewEngineList.find { it.renderingMode == RenderingMode.OPEN_GL_ES }!!,
-              modifier = Modifier
-                  .matchParentSize()
-                  .clickable(enabled = displayMode == DisplayMode.BOTH) {
-                      vulkanWeightValue = 0.1f
+              .weight(1f)
+              .fillMaxWidth(),
+            cameraData = vulkanCameraData,
+            renderingEngine = vulkanRenderingEngine,
+            onCameraChanged = { cameraMode ->
+              vulkanCameraData = CameraData(
+                cameraMode = when (cameraMode) {
+                  CameraMode.CAMERA_X -> {
+                    enginesCamera2.remove(vulkanRenderingEngine)
+                    if (enginesCameraX.contains(vulkanRenderingEngine).not()) {
+                      enginesCameraX.add(vulkanRenderingEngine)
+                    }
+                    CameraMode.CAMERA_X
                   }
-            )
-            Text(
-              text = "OpenGL",
-              fontSize = 20.sp,
-              color = Color.Black,
-              modifier = Modifier.padding(8.dp)
-            )
-          }
-        }
-        if (displayMode != DisplayMode.OPEN_GL_ES) {
-          Box(
-            contentAlignment = Alignment.TopStart,
-            modifier = Modifier
-                .weight(vulkanWeight)
-                .fillMaxWidth()
-          ) {
-            CameraPreviewView(
-              coreEngine = previewEngineList.find { it.renderingMode == RenderingMode.VULKAN }!!,
-              modifier = Modifier
-                  .matchParentSize()
-                  .clickable(enabled = displayMode == DisplayMode.BOTH) {
-                      openGlWeightValue = 0.1f
+
+                  CameraMode.CAMERA_2 -> {
+                    enginesCameraX.remove(vulkanRenderingEngine)
+                    if (enginesCamera2.contains(vulkanRenderingEngine).not()) {
+                      enginesCamera2.add(vulkanRenderingEngine)
+                    }
+                    CameraMode.CAMERA_2
                   }
-            )
-            Text(
-              text = "Vulkan",
-              fontSize = 20.sp,
-              color = Color.White,
-              modifier = Modifier.padding(8.dp)
-            )
-          }
-        }
-        if (cameraMode != CameraMode.NONE) {
-          Row {
-            Button(
-              onClick = {
-                lensFacing = if (lensFacing == CameraSelector.LENS_FACING_FRONT) {
-                  CameraSelector.LENS_FACING_BACK
-                } else {
-                  CameraSelector.LENS_FACING_FRONT
-                }
-              },
-              modifier = Modifier
-                  .padding(8.dp)
-                  .weight(1.0f)
-            ) {
-              Text(text = "Switch camera")
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-              Button(
-                onClick = {
-                  if (cameraMode == CameraMode.CAMERA_X) {
-                    cameraModeState.value = CameraMode.CAMERA_2
-                  } else {
-                    cameraModeState.value = CameraMode.CAMERA_X
-                  }
+
+                  CameraMode.NONE -> throw UnsupportedOperationException()
                 },
-                modifier = Modifier
-                    .padding(8.dp)
-                    .weight(1.0f)
-              ) {
-                Text(text = "To ${if (cameraMode == CameraMode.CAMERA_X) "Camera2" else "CameraX"}")
+                lensOrientation = vulkanCameraData.lensOrientation
+              )
+            },
+            onLensOrientationChanged = { lensOrientation ->
+              vulkanCameraData = CameraData(
+                cameraMode = vulkanCameraData.cameraMode,
+                lensOrientation = lensOrientation
+              )
+              if (openGlCameraData.cameraMode == vulkanCameraData.cameraMode) {
+                openGlCameraData = CameraData(openGlCameraData.cameraMode, lensOrientation)
               }
             }
-            if (displayMode != DisplayMode.BOTH && cameraMode != CameraMode.CAMERA_2) {
-              Button(
-                onClick = {
-                  displayMode = DisplayMode.BOTH
-                  vulkanWeightValue = 1.0f
-                  openGlWeightValue = 1.0f
+          )
+          CameraBox(
+            modifier = Modifier
+              .weight(1f)
+              .fillMaxWidth(),
+            cameraData = openGlCameraData,
+            renderingEngine = openGlRenderingEngine,
+            onCameraChanged = { cameraMode ->
+              openGlCameraData = CameraData(
+                cameraMode = when (cameraMode) {
+                  CameraMode.CAMERA_X -> {
+                    enginesCamera2.remove(openGlRenderingEngine)
+                    if (enginesCameraX.contains(openGlRenderingEngine).not()) {
+                      enginesCameraX.add(openGlRenderingEngine)
+                    }
+                    CameraMode.CAMERA_X
+                  }
+
+                  CameraMode.CAMERA_2 -> {
+                    enginesCameraX.remove(openGlRenderingEngine)
+                    if (enginesCamera2.contains(openGlRenderingEngine).not()) {
+                      enginesCamera2.add(openGlRenderingEngine)
+                    }
+                    CameraMode.CAMERA_2
+                  }
+
+                  CameraMode.NONE -> throw UnsupportedOperationException()
                 },
-                modifier = Modifier
-                    .padding(8.dp)
-                    .weight(1.0f)
-              ) {
-                Text(text = "Back to both")
+                lensOrientation = openGlCameraData.lensOrientation
+              )
+            },
+            onLensOrientationChanged = { lensOrientation ->
+              openGlCameraData = CameraData(
+                cameraMode = openGlCameraData.cameraMode,
+                lensOrientation = lensOrientation
+              )
+              if (openGlCameraData.cameraMode == vulkanCameraData.cameraMode) {
+                vulkanCameraData = CameraData(vulkanCameraData.cameraMode, lensOrientation)
               }
             }
-          }
+          )
+        }
+        if (vulkanCameraData.cameraMode == CameraMode.CAMERA_X || openGlCameraData.cameraMode == CameraMode.CAMERA_X) {
+          CameraX(
+            renderingEngines = enginesCameraX,
+            lensFacing = if (vulkanCameraData.cameraMode == CameraMode.CAMERA_X) {
+              vulkanCameraData.lensOrientation
+            } else if (openGlCameraData.cameraMode == CameraMode.CAMERA_X) {
+              openGlCameraData.lensOrientation
+            } else {
+              throw UnsupportedOperationException()
+            }
+          )
+        }
+
+        if (vulkanCameraData.cameraMode == CameraMode.CAMERA_2 || openGlCameraData.cameraMode == CameraMode.CAMERA_2) {
+          Camera2(
+            renderingEngines = enginesCamera2,
+            lensFacing = if (vulkanCameraData.cameraMode == CameraMode.CAMERA_2) {
+              vulkanCameraData.lensOrientation
+            } else if (openGlCameraData.cameraMode == CameraMode.CAMERA_2) {
+              openGlCameraData.lensOrientation
+            } else {
+              throw UnsupportedOperationException()
+            }
+          )
         }
       }
     }
@@ -237,13 +177,14 @@ class CameraActivity : ComponentActivity() {
     ) {
       requestPermissionLauncher.launch(Manifest.permission.CAMERA)
     } else {
-      cameraModeState.value = CameraMode.CAMERA_X
+      initialCameraMode = CameraMode.CAMERA_X
     }
   }
 
   override fun onDestroy() {
     super.onDestroy()
-    previewEngineList.forEach { it.destroy() }
+    openGlRenderingEngine.destroy()
+    vulkanRenderingEngine.destroy()
   }
 
   internal companion object {

--- a/app/src/main/java/com/dz/camerafast/CameraActivity.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraActivity.kt
@@ -10,7 +10,6 @@ import androidx.camera.core.CameraSelector
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -40,14 +39,6 @@ class CameraActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      val enginesCamera2 = remember {
-        mutableStateListOf(vulkanRenderingEngine, openGlRenderingEngine)
-      }
-
-      val enginesCameraX = remember {
-        mutableStateListOf(vulkanRenderingEngine, openGlRenderingEngine)
-      }
-
       var vulkanCameraData by remember {
         mutableStateOf(CameraData(initialCameraMode, CameraSelector.LENS_FACING_FRONT))
       }
@@ -55,6 +46,13 @@ class CameraActivity : ComponentActivity() {
       var openGlCameraData by remember {
         mutableStateOf(CameraData(initialCameraMode, CameraSelector.LENS_FACING_FRONT))
       }
+
+      // When an engine moves onto the source the other engine is already on, adopt
+      // the other engine's lens so both states agree before the camera opens.
+      fun moveTo(self: CameraData, other: CameraData, target: CameraMode) = CameraData(
+        cameraMode = target,
+        lensOrientation = if (other.cameraMode == target) other.lensOrientation else self.lensOrientation
+      )
 
       if (vulkanCameraData.cameraMode != CameraMode.NONE) {
         Column {
@@ -65,36 +63,12 @@ class CameraActivity : ComponentActivity() {
             cameraData = vulkanCameraData,
             renderingEngine = vulkanRenderingEngine,
             onCameraChanged = { cameraMode ->
-              vulkanCameraData = CameraData(
-                cameraMode = when (cameraMode) {
-                  CameraMode.CAMERA_X -> {
-                    enginesCamera2.remove(vulkanRenderingEngine)
-                    if (enginesCameraX.contains(vulkanRenderingEngine).not()) {
-                      enginesCameraX.add(vulkanRenderingEngine)
-                    }
-                    CameraMode.CAMERA_X
-                  }
-
-                  CameraMode.CAMERA_2 -> {
-                    enginesCameraX.remove(vulkanRenderingEngine)
-                    if (enginesCamera2.contains(vulkanRenderingEngine).not()) {
-                      enginesCamera2.add(vulkanRenderingEngine)
-                    }
-                    CameraMode.CAMERA_2
-                  }
-
-                  CameraMode.NONE -> throw UnsupportedOperationException()
-                },
-                lensOrientation = vulkanCameraData.lensOrientation
-              )
+              vulkanCameraData = moveTo(vulkanCameraData, openGlCameraData, cameraMode)
             },
             onLensOrientationChanged = { lensOrientation ->
-              vulkanCameraData = CameraData(
-                cameraMode = vulkanCameraData.cameraMode,
-                lensOrientation = lensOrientation
-              )
+              vulkanCameraData = vulkanCameraData.copy(lensOrientation = lensOrientation)
               if (openGlCameraData.cameraMode == vulkanCameraData.cameraMode) {
-                openGlCameraData = CameraData(openGlCameraData.cameraMode, lensOrientation)
+                openGlCameraData = openGlCameraData.copy(lensOrientation = lensOrientation)
               }
             }
           )
@@ -105,62 +79,43 @@ class CameraActivity : ComponentActivity() {
             cameraData = openGlCameraData,
             renderingEngine = openGlRenderingEngine,
             onCameraChanged = { cameraMode ->
-              openGlCameraData = CameraData(
-                cameraMode = when (cameraMode) {
-                  CameraMode.CAMERA_X -> {
-                    enginesCamera2.remove(openGlRenderingEngine)
-                    if (enginesCameraX.contains(openGlRenderingEngine).not()) {
-                      enginesCameraX.add(openGlRenderingEngine)
-                    }
-                    CameraMode.CAMERA_X
-                  }
-
-                  CameraMode.CAMERA_2 -> {
-                    enginesCameraX.remove(openGlRenderingEngine)
-                    if (enginesCamera2.contains(openGlRenderingEngine).not()) {
-                      enginesCamera2.add(openGlRenderingEngine)
-                    }
-                    CameraMode.CAMERA_2
-                  }
-
-                  CameraMode.NONE -> throw UnsupportedOperationException()
-                },
-                lensOrientation = openGlCameraData.lensOrientation
-              )
+              openGlCameraData = moveTo(openGlCameraData, vulkanCameraData, cameraMode)
             },
             onLensOrientationChanged = { lensOrientation ->
-              openGlCameraData = CameraData(
-                cameraMode = openGlCameraData.cameraMode,
-                lensOrientation = lensOrientation
-              )
+              openGlCameraData = openGlCameraData.copy(lensOrientation = lensOrientation)
               if (openGlCameraData.cameraMode == vulkanCameraData.cameraMode) {
-                vulkanCameraData = CameraData(vulkanCameraData.cameraMode, lensOrientation)
+                vulkanCameraData = vulkanCameraData.copy(lensOrientation = lensOrientation)
               }
             }
           )
         }
-        if (vulkanCameraData.cameraMode == CameraMode.CAMERA_X || openGlCameraData.cameraMode == CameraMode.CAMERA_X) {
+
+        val cameraXEngines = buildList {
+          if (vulkanCameraData.cameraMode == CameraMode.CAMERA_X) add(vulkanRenderingEngine)
+          if (openGlCameraData.cameraMode == CameraMode.CAMERA_X) add(openGlRenderingEngine)
+        }
+        if (cameraXEngines.isNotEmpty()) {
           CameraX(
-            renderingEngines = enginesCameraX,
+            renderingEngines = cameraXEngines,
             lensFacing = if (vulkanCameraData.cameraMode == CameraMode.CAMERA_X) {
               vulkanCameraData.lensOrientation
-            } else if (openGlCameraData.cameraMode == CameraMode.CAMERA_X) {
-              openGlCameraData.lensOrientation
             } else {
-              throw UnsupportedOperationException()
+              openGlCameraData.lensOrientation
             }
           )
         }
 
-        if (vulkanCameraData.cameraMode == CameraMode.CAMERA_2 || openGlCameraData.cameraMode == CameraMode.CAMERA_2) {
+        val camera2Engines = buildList {
+          if (vulkanCameraData.cameraMode == CameraMode.CAMERA_2) add(vulkanRenderingEngine)
+          if (openGlCameraData.cameraMode == CameraMode.CAMERA_2) add(openGlRenderingEngine)
+        }
+        if (camera2Engines.isNotEmpty()) {
           Camera2(
-            renderingEngines = enginesCamera2,
+            renderingEngines = camera2Engines,
             lensFacing = if (vulkanCameraData.cameraMode == CameraMode.CAMERA_2) {
               vulkanCameraData.lensOrientation
-            } else if (openGlCameraData.cameraMode == CameraMode.CAMERA_2) {
-              openGlCameraData.lensOrientation
             } else {
-              throw UnsupportedOperationException()
+              openGlCameraData.lensOrientation
             }
           )
         }

--- a/app/src/main/java/com/dz/camerafast/CameraBox.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraBox.kt
@@ -1,0 +1,84 @@
+package com.dz.camerafast
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.camera.core.CameraSelector
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.dz.camerafast.camera.CameraData
+
+@RequiresApi(Build.VERSION_CODES.Q)
+@Composable
+fun CameraBox(
+  modifier: Modifier = Modifier,
+  cameraData: CameraData,
+  renderingEngine: RenderingEngine,
+  onCameraChanged: (CameraMode) -> Unit,
+  onLensOrientationChanged: (Int) -> Unit,
+) {
+  Box(modifier = modifier) {
+    CameraPreviewView(
+      modifier = Modifier.matchParentSize(),
+      renderingEngine = renderingEngine
+    )
+    Text(
+      text = "${cameraData.cameraMode.name} | ${renderingEngine.mode.name}",
+      color = Color.White,
+      textAlign = TextAlign.Center,
+      fontSize = 16.sp,
+      modifier = Modifier
+        .background(Color.DarkGray)
+        .fillMaxWidth()
+        .padding(10.dp)
+    )
+    // Camera2 with needed config is not supported for all devices
+    // and also is not yet supported for Vulkan
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && renderingEngine.mode != RenderingMode.VULKAN) {
+      FloatingActionButton(
+        modifier = Modifier.align(Alignment.BottomEnd),
+        onClick = {
+          when (cameraData.cameraMode) {
+            CameraMode.CAMERA_X -> onCameraChanged.invoke(CameraMode.CAMERA_2)
+            CameraMode.CAMERA_2 -> onCameraChanged.invoke(CameraMode.CAMERA_X)
+            CameraMode.NONE -> throw UnsupportedOperationException()
+          }
+        }
+      ) {
+        Icon(
+          imageVector = Icons.Default.PlayArrow,
+          contentDescription = "Switch camera"
+        )
+      }
+    }
+    FloatingActionButton(
+      modifier = Modifier.align(Alignment.BottomStart),
+      onClick = {
+        if (cameraData.lensOrientation == CameraSelector.LENS_FACING_BACK) {
+          onLensOrientationChanged(CameraSelector.LENS_FACING_FRONT)
+        } else if (cameraData.lensOrientation == CameraSelector.LENS_FACING_FRONT) {
+          onLensOrientationChanged(CameraSelector.LENS_FACING_BACK)
+        }
+      }
+    ) {
+      Icon(
+        imageVector = Icons.Default.Refresh,
+        contentDescription = "Switch camera lens"
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/dz/camerafast/CameraPreviewView.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraPreviewView.kt
@@ -9,13 +9,13 @@ import androidx.compose.ui.viewinterop.AndroidView
 @SuppressLint("UnsafeOptInUsageError")
 @Composable
 fun CameraPreviewView(
-  coreEngine: CoreEngine,
+  renderingEngine: RenderingEngine,
   modifier: Modifier = Modifier
 ) {
   AndroidView(
     modifier = modifier,
     factory = { context ->
-      SurfaceView(context).apply { coreEngine.surfaceHolder = this.holder }
+      SurfaceView(context).apply { renderingEngine.surfaceHolder = this.holder }
     },
     update = {
       // could not be used efficiently as this will always be called from main thread

--- a/app/src/main/java/com/dz/camerafast/DisplayMode.kt
+++ b/app/src/main/java/com/dz/camerafast/DisplayMode.kt
@@ -1,7 +1,0 @@
-package com.dz.camerafast
-
-enum class DisplayMode {
-  BOTH,
-  VULKAN,
-  OPEN_GL_ES
-}

--- a/app/src/main/java/com/dz/camerafast/RenderingEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/RenderingEngine.kt
@@ -8,8 +8,8 @@ import android.view.SurfaceHolder
 import androidx.annotation.Keep
 
 @Keep
-class CoreEngine(
-  val renderingMode: RenderingMode,
+class RenderingEngine(
+  val mode: RenderingMode,
 ) : SurfaceHolder.Callback {
 
   internal var surfaceHolder: SurfaceHolder? = null
@@ -23,7 +23,7 @@ class CoreEngine(
     }
 
   init {
-    initialize(renderingMode.ordinal)
+    initialize(mode.ordinal)
   }
 
   fun sendCameraFrame(buffer: HardwareBuffer, rotationDegrees: Int, backCamera: Boolean) {

--- a/app/src/main/java/com/dz/camerafast/camera/Camera2.kt
+++ b/app/src/main/java/com/dz/camerafast/camera/Camera2.kt
@@ -1,4 +1,4 @@
-package com.dz.camerafast
+package com.dz.camerafast.camera
 
 import android.annotation.SuppressLint
 import android.content.Context
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LifecycleStartEffect
 import com.dz.camerafast.CameraActivity.Companion.TAG
+import com.dz.camerafast.RenderingEngine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -33,7 +34,7 @@ import kotlin.coroutines.resume
 @RequiresApi(Build.VERSION_CODES.Q)
 @Composable
 fun Camera2(
-  coreEngines: List<CoreEngine>,
+  renderingEngines: List<RenderingEngine>,
   lensFacing: Int,
   context: Context = LocalContext.current,
   coroutineScope: CoroutineScope = rememberCoroutineScope()
@@ -116,7 +117,7 @@ fun Camera2(
         {
           val image = it.acquireLatestImage()
           image.hardwareBuffer?.let { buffer ->
-            coreEngines.forEach { engine ->
+            renderingEngines.forEach { engine ->
               engine.sendCameraFrame(
                 buffer = buffer,
                 rotationDegrees = rotationDegrees,

--- a/app/src/main/java/com/dz/camerafast/camera/Camera2.kt
+++ b/app/src/main/java/com/dz/camerafast/camera/Camera2.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LifecycleStartEffect
@@ -47,6 +48,11 @@ fun Camera2(
   val cameraManager: CameraManager by lazy {
     context.applicationContext.getSystemService(Context.CAMERA_SERVICE) as CameraManager
   }
+
+  // Wrapped so the per-frame listener (set once when the camera opens) always sees
+  // the current engine list — engines can hop between Camera2 and CameraX mid-stream
+  // without reopening the camera.
+  val currentRenderingEngines by rememberUpdatedState(renderingEngines)
 
   var currentCameraDevice: CameraDevice? by remember {
     mutableStateOf(null)
@@ -117,7 +123,7 @@ fun Camera2(
         {
           val image = it.acquireLatestImage()
           image.hardwareBuffer?.let { buffer ->
-            renderingEngines.forEach { engine ->
+            currentRenderingEngines.forEach { engine ->
               engine.sendCameraFrame(
                 buffer = buffer,
                 rotationDegrees = rotationDegrees,

--- a/app/src/main/java/com/dz/camerafast/camera/CameraData.kt
+++ b/app/src/main/java/com/dz/camerafast/camera/CameraData.kt
@@ -1,0 +1,10 @@
+package com.dz.camerafast.camera
+
+import androidx.compose.runtime.Immutable
+import com.dz.camerafast.CameraMode
+
+@Immutable
+data class CameraData(
+  val cameraMode: CameraMode,
+  val lensOrientation: Int,
+)

--- a/app/src/main/java/com/dz/camerafast/camera/CameraX.kt
+++ b/app/src/main/java/com/dz/camerafast/camera/CameraX.kt
@@ -1,4 +1,4 @@
-package com.dz.camerafast
+package com.dz.camerafast.camera
 
 import android.content.Context
 import android.util.Log
@@ -15,12 +15,13 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LifecycleStartEffect
 import com.dz.camerafast.CameraActivity.Companion.TAG
+import com.dz.camerafast.RenderingEngine
 import java.util.concurrent.Executors
 
 @OptIn(ExperimentalGetImage::class)
 @Composable
 fun CameraX(
-  coreEngines: List<CoreEngine>,
+  renderingEngines: List<RenderingEngine>,
   lensFacing: Int,
   context: Context = LocalContext.current
 ) {
@@ -44,7 +45,7 @@ fun CameraX(
       imageAnalysis.setAnalyzer(Executors.newSingleThreadExecutor()) { imageProxy ->
         Log.i(TAG, "New image ${imageProxy.hashCode()} arrived!")
         imageProxy.image?.hardwareBuffer?.let { buffer ->
-          coreEngines.forEach {
+          renderingEngines.forEach {
             it.sendCameraFrame(
               buffer = buffer,
               rotationDegrees = imageProxy.imageInfo.rotationDegrees,

--- a/app/src/main/java/com/dz/camerafast/camera/CameraX.kt
+++ b/app/src/main/java/com/dz/camerafast/camera/CameraX.kt
@@ -10,6 +10,8 @@ import androidx.camera.core.resolutionselector.AspectRatioStrategy
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
@@ -25,6 +27,11 @@ fun CameraX(
   lensFacing: Int,
   context: Context = LocalContext.current
 ) {
+  // Wrapped so the analyzer (set once per camera open) always sees the current
+  // engine list — engines can hop between Camera2 and CameraX mid-stream without
+  // reopening the camera.
+  val currentRenderingEngines by rememberUpdatedState(renderingEngines)
+
   LifecycleStartEffect(lensFacing) {
     val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
     cameraProviderFuture.addListener({
@@ -45,7 +52,7 @@ fun CameraX(
       imageAnalysis.setAnalyzer(Executors.newSingleThreadExecutor()) { imageProxy ->
         Log.i(TAG, "New image ${imageProxy.hashCode()} arrived!")
         imageProxy.image?.hardwareBuffer?.let { buffer ->
-          renderingEngines.forEach {
+          currentRenderingEngines.forEach {
             it.sendCameraFrame(
               buffer = buffer,
               rotationDegrees = imageProxy.imageInfo.rotationDegrees,

--- a/app/src/main/native/cpp/main.cpp
+++ b/app/src/main/native/cpp/main.cpp
@@ -1,11 +1,11 @@
 #include <jni/jni.hpp>
 
-#include "core_engine.hpp"
+#include "rendering_engine.hpp"
 
 extern "C" JNIEXPORT jint
 
 JNICALL JNI_OnLoad(JavaVM *vm, void *) {
   jni::JNIEnv &env = jni::GetEnv(*vm);
-  engine::android::CoreEngine::registerNatives(env);
+  engine::android::RenderingEngine::registerNatives(env);
   return JNI_VERSION_1_6;
 }

--- a/app/src/main/native/cpp/rendering_engine.cpp
+++ b/app/src/main/native/cpp/rendering_engine.cpp
@@ -1,9 +1,9 @@
-#include "core_engine.hpp"
+#include "rendering_engine.hpp"
 
 namespace engine {
 namespace android {
 
-CoreEngine::CoreEngine(JNIEnv &env, jni::jint renderingMode) : aNativeWindow(nullptr) {
+RenderingEngine::RenderingEngine(JNIEnv &env, jni::jint renderingMode) : aNativeWindow(nullptr) {
   switch (renderingMode) {
     case 0: {
       LOGI("Using OpenGL ES renderer");
@@ -21,11 +21,11 @@ CoreEngine::CoreEngine(JNIEnv &env, jni::jint renderingMode) : aNativeWindow(nul
   }
 }
 
-CoreEngine::~CoreEngine() = default;
+RenderingEngine::~RenderingEngine() = default;
 
 /** called from Android main thread **/
-void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surface,
-                                  jni::jint width, jni::jint height) {
+void RenderingEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surface,
+                                       jni::jint width, jni::jint height) {
   if (surface.get() != nullptr) {
     auto *nativeWindow = ANativeWindow_fromSurface(&env, jni::Unwrap(*surface.get()));
     if (nativeWindow != aNativeWindow) {
@@ -44,8 +44,8 @@ void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surfa
 }
 
 /** called from worker thread **/
-void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBuffer> &buffer,
-                                       jni::jint rotationDegrees, jni::jboolean backCamera) {
+void RenderingEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBuffer> &buffer,
+                                            jni::jint rotationDegrees, jni::jboolean backCamera) {
   auto cameraBuffer = AHardwareBuffer_fromHardwareBuffer(&env, jni::Unwrap(*buffer.get()));
   AHardwareBuffer_Desc cameraBufferDescription;
   AHardwareBuffer_describe(cameraBuffer, &cameraBufferDescription);
@@ -75,7 +75,7 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
   }
 }
 
-void CoreEngine::nativeDestroy(JNIEnv &env) {
+void RenderingEngine::nativeDestroy(JNIEnv &env) {
   LOGI("Core engine destroy started");
   renderer.reset();
   LOGI("Core engine destroy passed");

--- a/app/src/main/native/cpp/rendering_engine.hpp
+++ b/app/src/main/native/cpp/rendering_engine.hpp
@@ -25,31 +25,31 @@ public:
   static constexpr auto Name() { return "android/hardware/HardwareBuffer"; }
 };
 
-class CoreEngine {
+class RenderingEngine {
 
 public:
-  static constexpr auto Name() { return "com/dz/camerafast/CoreEngine"; }
+  static constexpr auto Name() { return "com/dz/camerafast/RenderingEngine"; }
 
   static void registerNatives(JNIEnv &env) {
-    jni::Class<CoreEngine>::Singleton(env);
-    jni::RegisterNativePeer<CoreEngine>(
+    jni::Class<RenderingEngine>::Singleton(env);
+    jni::RegisterNativePeer<RenderingEngine>(
             env,
-            jni::Class<CoreEngine>::Find(env),
+            jni::Class<RenderingEngine>::Find(env),
             "peer",
-            jni::MakePeer < CoreEngine, jni::jint > ,
+            jni::MakePeer < RenderingEngine, jni::jint > ,
             "initialize",
             "finalize",
-            METHOD(&CoreEngine::nativeSetSurface, "nativeSetSurface"),
-            METHOD(&CoreEngine::nativeSendCameraFrame, "nativeSendCameraFrame"),
-            METHOD(&CoreEngine::nativeDestroy, "nativeDestroy")
+            METHOD(&RenderingEngine::nativeSetSurface, "nativeSetSurface"),
+            METHOD(&RenderingEngine::nativeSendCameraFrame, "nativeSendCameraFrame"),
+            METHOD(&RenderingEngine::nativeDestroy, "nativeDestroy")
     );
   }
 
-  CoreEngine(JNIEnv &env, jni::jint renderingMode);
+  RenderingEngine(JNIEnv &env, jni::jint renderingMode);
 
-  CoreEngine(CoreEngine const &) = delete;
+  RenderingEngine(RenderingEngine const &) = delete;
 
-  ~CoreEngine();
+  ~RenderingEngine();
 
   void nativeSetSurface(JNIEnv &env, jni::Object <Surface> const &surface, jni::jint width,
                         jni::jint height);


### PR DESCRIPTION
Make each rendering engine (Vulkan, OpenGL) independently choose its camera source (Camera2 vs CameraX) and lens facing. CameraBox wraps each preview with its own FAB controls; the activity mounts Camera2 and/or CameraX based on which engines are currently using each source. Lens facing stays in sync when both engines share a camera source.

Native: CoreEngine renamed to RenderingEngine (C++ class, header, JNI peer, CMake project). Kotlin Camera2/CameraX moved into the camera/ sub-package.