### PR TITLE
Use TextureView's and animated transitions

### DIFF
--- a/app/src/main/java/com/dz/camerafast/Camera2.kt
+++ b/app/src/main/java/com/dz/camerafast/Camera2.kt
@@ -9,6 +9,7 @@ import android.hardware.camera2.CameraCaptureSession.StateCallback
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
+import android.media.Image
 import android.media.ImageReader
 import android.os.Build
 import android.os.Handler
@@ -114,8 +115,8 @@ fun Camera2(
         cameraCharacteristics.get(CameraCharacteristics.SENSOR_ORIENTATION)!!
       imageReader.setOnImageAvailableListener(
         {
-          val image = it.acquireLatestImage()
-          image.hardwareBuffer?.let { buffer ->
+          val image: Image? = it.acquireLatestImage()
+          image?.hardwareBuffer?.let { buffer ->
             coreEngines.forEach { engine ->
               engine.sendCameraFrame(
                 buffer = buffer,
@@ -125,7 +126,7 @@ fun Camera2(
             }
             buffer.close()
           }
-          image.close()
+          image?.close()
         },
         cameraHandler
       )

--- a/app/src/main/java/com/dz/camerafast/CameraActivity.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraActivity.kt
@@ -144,10 +144,8 @@ class CameraActivity : ComponentActivity() {
           Box(
             contentAlignment = Alignment.TopStart,
             modifier = Modifier
-                // Modifier.weight requires a strictly positive value, so floor at a sub-pixel
-                // weight. Animating the state to 0.0 (see click handlers below) thus lands here as
-                // an imperceptible sliver right before the finishedListener removes the Box —
-                // smooth all the way to "gone" instead of jumping from a visible 10% slice.
+                // Modifier.weight requires a strictly positive value,
+                // so floor at a sub-pixel weight
                 .weight(openGlWeight.coerceAtLeast(MIN_WEIGHT))
                 .fillMaxWidth()
           ) {

--- a/app/src/main/java/com/dz/camerafast/CameraActivity.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraActivity.kt
@@ -102,10 +102,6 @@ class CameraActivity : ComponentActivity() {
         }
       )
 
-      // Hand each engine its own preview weight on every recomposition (each animation frame
-      // produces one). CoreEngine.refit filters internally and only fires a JNI call at key
-      // frames (threshold crossings + endpoint settlement), so a 0 -> 1 grow gets a few re-fits
-      // along the way instead of presenting one stale tiny buffer the whole time.
       SideEffect {
         previewEngineList.find { it.renderingMode == RenderingMode.VULKAN }!!
           .refit(vulkanWeight)
@@ -144,8 +140,6 @@ class CameraActivity : ComponentActivity() {
           Box(
             contentAlignment = Alignment.TopStart,
             modifier = Modifier
-                // Modifier.weight requires a strictly positive value,
-                // so floor at a sub-pixel weight
                 .weight(openGlWeight.coerceAtLeast(MIN_WEIGHT))
                 .fillMaxWidth()
           ) {
@@ -261,10 +255,7 @@ class CameraActivity : ComponentActivity() {
   internal companion object {
     internal const val TAG = "DzCamera"
 
-    // Minimum weight applied to a shrinking preview Box. Modifier.weight requires a strictly
-    // positive value, so we coerce the animated weight to this sub-pixel floor — the Box's actual
-    // height rounds to 0px well before the animation reaches it, making the final removal
-    // (in finishedListener) imperceptible.
+    // Modifier.weight requires a strictly positive value; floor the animated weight here.
     private const val MIN_WEIGHT = 0.0001f
   }
 }

--- a/app/src/main/java/com/dz/camerafast/CameraActivity.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.Text
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -73,8 +74,7 @@ class CameraActivity : ComponentActivity() {
 
       val vulkanWeight by animateFloatAsState(
         targetValue = vulkanWeightValue,
-        // TODO increase duration and try make dynamic view resize less laggy
-        animationSpec = tween(durationMillis = 0),
+        animationSpec = tween(durationMillis = 1000),
         label = "Vulkan",
         finishedListener = { endValue ->
           displayMode = if (endValue == 1.0f) {
@@ -91,8 +91,7 @@ class CameraActivity : ComponentActivity() {
 
       val openGlWeight by animateFloatAsState(
         targetValue = openGlWeightValue,
-        // TODO increase duration and try make dynamic view resize less laggy
-        animationSpec = tween(durationMillis = 0),
+        animationSpec = tween(durationMillis = 1000),
         label = "OpenGL",
         finishedListener = { endValue ->
           displayMode = if (endValue == 1.0f) {
@@ -102,6 +101,17 @@ class CameraActivity : ComponentActivity() {
           }
         }
       )
+
+      // Hand each engine its own preview weight on every recomposition (each animation frame
+      // produces one). CoreEngine.refit filters internally and only fires a JNI call at key
+      // frames (threshold crossings + endpoint settlement), so a 0 -> 1 grow gets a few re-fits
+      // along the way instead of presenting one stale tiny buffer the whole time.
+      SideEffect {
+        previewEngineList.find { it.renderingMode == RenderingMode.VULKAN }!!
+          .refit(vulkanWeight)
+        previewEngineList.find { it.renderingMode == RenderingMode.OPEN_GL_ES }!!
+          .refit(openGlWeight)
+      }
 
       if (cameraMode == CameraMode.CAMERA_X) {
         CameraX(
@@ -134,7 +144,11 @@ class CameraActivity : ComponentActivity() {
           Box(
             contentAlignment = Alignment.TopStart,
             modifier = Modifier
-                .weight(openGlWeight)
+                // Modifier.weight requires a strictly positive value, so floor at a sub-pixel
+                // weight. Animating the state to 0.0 (see click handlers below) thus lands here as
+                // an imperceptible sliver right before the finishedListener removes the Box —
+                // smooth all the way to "gone" instead of jumping from a visible 10% slice.
+                .weight(openGlWeight.coerceAtLeast(MIN_WEIGHT))
                 .fillMaxWidth()
           ) {
             CameraPreviewView(
@@ -142,7 +156,7 @@ class CameraActivity : ComponentActivity() {
               modifier = Modifier
                   .matchParentSize()
                   .clickable(enabled = displayMode == DisplayMode.BOTH) {
-                      vulkanWeightValue = 0.1f
+                      vulkanWeightValue = 0.0f
                   }
             )
             Text(
@@ -157,7 +171,7 @@ class CameraActivity : ComponentActivity() {
           Box(
             contentAlignment = Alignment.TopStart,
             modifier = Modifier
-                .weight(vulkanWeight)
+                .weight(vulkanWeight.coerceAtLeast(MIN_WEIGHT))
                 .fillMaxWidth()
           ) {
             CameraPreviewView(
@@ -165,7 +179,7 @@ class CameraActivity : ComponentActivity() {
               modifier = Modifier
                   .matchParentSize()
                   .clickable(enabled = displayMode == DisplayMode.BOTH) {
-                      openGlWeightValue = 0.1f
+                      openGlWeightValue = 0.0f
                   }
             )
             Text(
@@ -248,5 +262,11 @@ class CameraActivity : ComponentActivity() {
 
   internal companion object {
     internal const val TAG = "DzCamera"
+
+    // Minimum weight applied to a shrinking preview Box. Modifier.weight requires a strictly
+    // positive value, so we coerce the animated weight to this sub-pixel floor — the Box's actual
+    // height rounds to 0px well before the animation reaches it, making the final removal
+    // (in finishedListener) imperceptible.
+    private const val MIN_WEIGHT = 0.0001f
   }
 }

--- a/app/src/main/java/com/dz/camerafast/CameraPreviewView.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraPreviewView.kt
@@ -1,7 +1,7 @@
 package com.dz.camerafast
 
 import android.annotation.SuppressLint
-import android.view.SurfaceView
+import android.view.TextureView
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
@@ -15,7 +15,7 @@ fun CameraPreviewView(
   AndroidView(
     modifier = modifier,
     factory = { context ->
-      SurfaceView(context).apply { coreEngine.surfaceHolder = this.holder }
+      TextureView(context).apply { coreEngine.textureView = this }
     },
     update = {
       // could not be used efficiently as this will always be called from main thread

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -80,6 +80,10 @@ class CoreEngine(
     if (textureView?.surfaceTexture === surfaceTexture) {
       textureView = null
     }
+    // Returning true tells TextureView to release the SurfaceTexture itself (per the contract on
+    // SurfaceTextureListener.onSurfaceTextureDestroyed: true = framework releases, false = we
+    // take ownership and must call SurfaceTexture.release() ourselves). We don't keep the
+    // SurfaceTexture beyond this callback, so framework-side release is correct.
     return true
   }
 

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -16,13 +16,11 @@ class CoreEngine(
 
   internal var textureView: TextureView? = null
     set(value) {
-      // remove listener for previous camera preview view if needed
       field?.surfaceTextureListener = null
       field = value
       field?.surfaceTextureListener = this
-      // If the TextureView already has a SurfaceTexture (common when the view is re-attached or
-      // the listener is set after layout), the framework won't fire onSurfaceTextureAvailable —
-      // do it ourselves so the native surface still gets set up.
+      // If the TextureView is already available, the framework won't fire
+      // onSurfaceTextureAvailable — invoke it ourselves.
       if (value?.isAvailable == true) {
         value.surfaceTexture?.let { texture ->
           onSurfaceTextureAvailable(texture, value.width, value.height)
@@ -41,15 +39,7 @@ class CoreEngine(
 
   private var previousWeight: Float = 1.0f
 
-  /**
-   * Called by the UI on every preview-weight change (e.g. from a Compose SideEffect over an
-   * animateFloatAsState value). When the transition crosses one of [REFIT_THRESHOLDS] or settles
-   * at an endpoint (0.0 / 1.0), the renderer is asked to re-fit its output to the current view
-   * bounds — that's a swapchain rebuild for Vulkan and a glViewport for OpenGL. Intermediate
-   * animation ticks are filtered out here so the JNI layer only sees the values worth reacting to.
-   *
-   * @return true if this transition actually triggered a native refit.
-   */
+  /** Pushes the current preview weight; triggers a native refit at threshold crossings only. */
   fun refit(weight: Float): Boolean {
     val triggered = shouldRefit(previousWeight, weight)
     previousWeight = weight
@@ -61,6 +51,7 @@ class CoreEngine(
 
   override fun onSurfaceTextureAvailable(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
     Log.i(TAG, "Surface texture available, width $width, height $height")
+    // Release any stale Surface from a previous binding before overwriting the field.
     surface?.release()
     surface = Surface(surfaceTexture).also { nativeSetSurface(it, width, height) }
   }
@@ -74,16 +65,12 @@ class CoreEngine(
     nativeSetSurface(null, 0, 0)
     surface?.release()
     surface = null
-    // Drop the TextureView reference (the setter also detaches our listener) so a destroyed view
-    // can be GC'd along with its Context. Guard with an identity check so an unrelated callback
-    // from a stale SurfaceTexture wouldn't accidentally null out a freshly-attached TextureView.
+    // Drop the TextureView reference so the destroyed view can be GC'd. Identity-guard against
+    // stale callbacks from an older SurfaceTexture.
     if (textureView?.surfaceTexture === surfaceTexture) {
       textureView = null
     }
-    // Returning true tells TextureView to release the SurfaceTexture itself (per the contract on
-    // SurfaceTextureListener.onSurfaceTextureDestroyed: true = framework releases, false = we
-    // take ownership and must call SurfaceTexture.release() ourselves). We don't keep the
-    // SurfaceTexture beyond this callback, so framework-side release is correct.
+    // true = let TextureView release the SurfaceTexture for us.
     return true
   }
 
@@ -161,10 +148,6 @@ class CoreEngine(
   private companion object {
     private const val TAG = "DzCoreKotlin"
 
-    // Weight values at which the renderer should re-fit (Vulkan rebuilds its swapchain, OpenGL
-    // runs glViewport). Crossings of these thresholds — plus endpoint settlement at 0.0 / 1.0 —
-    // are the only events forwarded to JNI. Intermediate animation ticks are dropped client-side
-    // so the native layer doesn't have to track previous values or implement crossing detection.
     private val REFIT_THRESHOLDS = floatArrayOf(0.1f, 0.5f)
 
     private fun shouldRefit(prev: Float, curr: Float): Boolean {
@@ -173,10 +156,6 @@ class CoreEngine(
         val crossedDown = prev > threshold && curr <= threshold
         if (crossedUp || crossedDown) return true
       }
-      // Endpoint settlement: detect transitions INTO the rest region rather than equality with
-      // exactly 0f / 1f. animateFloatAsState with tween lands precisely on the target today, but
-      // spring or other animation specs can overshoot or settle slightly past — using <= 0f /
-      // >= 1f keeps the final refit reliable across animation-spec changes.
       val settledAtZero = curr <= 0.0f && prev > 0.0f
       val settledAtOne = curr >= 1.0f && prev < 1.0f
       return settledAtZero || settledAtOne

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -60,7 +60,11 @@ class CoreEngine(
 
   override fun onSurfaceTextureSizeChanged(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
     Log.i(TAG, "Surface texture size changed, width $width, height $height")
-    nativeSetSurface(surface, width, height)
+    // Size-only path: avoid going through nativeSetSurface here, because that route would call
+    // ANativeWindow_fromSurface on every tick — each call returns a fresh +1 reference that we
+    // don't release in the same-window branch, so it would leak one ANativeWindow ref per frame
+    // of the resize animation.
+    nativeUpdateWindowSize(width, height)
   }
 
   override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
@@ -84,6 +88,8 @@ class CoreEngine(
   var peer: Long = 0
 
   private external fun nativeSetSurface(surface: Surface?, width: Int, height: Int)
+
+  private external fun nativeUpdateWindowSize(width: Int, height: Int)
 
   private external fun nativeSendCameraFrame(
     buffer: HardwareBuffer,

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -39,8 +39,6 @@ class CoreEngine(
     nativeSendCameraFrame(buffer, rotationDegrees, backCamera)
   }
 
-  // Last preview weight passed to refit(). Only read/written from whichever thread the UI calls
-  // refit() on (Compose's main thread via SideEffect), so no synchronization needed.
   private var previousWeight: Float = 1.0f
 
   /**
@@ -63,15 +61,12 @@ class CoreEngine(
 
   override fun onSurfaceTextureAvailable(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
     Log.i(TAG, "Surface texture available, width $width, height $height")
+    surface?.release()
     surface = Surface(surfaceTexture).also { nativeSetSurface(it, width, height) }
   }
 
   override fun onSurfaceTextureSizeChanged(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
     Log.i(TAG, "Surface texture size changed, width $width, height $height")
-    // Size-only path: avoid going through nativeSetSurface here, because that route would call
-    // ANativeWindow_fromSurface on every tick — each call returns a fresh +1 reference that we
-    // don't release in the same-window branch, so it would leak one ANativeWindow ref per frame
-    // of the resize animation.
     nativeUpdateWindowSize(width, height)
   }
 

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -20,6 +20,14 @@ class CoreEngine(
       field?.surfaceTextureListener = null
       field = value
       field?.surfaceTextureListener = this
+      // If the TextureView already has a SurfaceTexture (common when the view is re-attached or
+      // the listener is set after layout), the framework won't fire onSurfaceTextureAvailable —
+      // do it ourselves so the native surface still gets set up.
+      if (value?.isAvailable == true) {
+        value.surfaceTexture?.let { texture ->
+          onSurfaceTextureAvailable(texture, value.width, value.height)
+        }
+      }
     }
 
   init {

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -1,25 +1,25 @@
 package com.dz.camerafast
 
-import android.graphics.PixelFormat
+import android.graphics.SurfaceTexture
 import android.hardware.HardwareBuffer
 import android.util.Log
 import android.view.Surface
-import android.view.SurfaceHolder
+import android.view.TextureView
 import androidx.annotation.Keep
 
 @Keep
 class CoreEngine(
   val renderingMode: RenderingMode,
-) : SurfaceHolder.Callback {
+) : TextureView.SurfaceTextureListener {
 
-  internal var surfaceHolder: SurfaceHolder? = null
+  private var surface: Surface? = null
+
+  internal var textureView: TextureView? = null
     set(value) {
-      // remove callback for previous camera preview view if needed
-      field?.removeCallback(this)
+      // remove listener for previous camera preview view if needed
+      field?.surfaceTextureListener = null
       field = value
-      // we will use RGBA_8888 here and use same config in render thread
-      field?.setFormat(PixelFormat.RGBA_8888)
-      field?.addCallback(this)
+      field?.surfaceTextureListener = this
     }
 
   init {
@@ -31,17 +31,47 @@ class CoreEngine(
     nativeSendCameraFrame(buffer, rotationDegrees, backCamera)
   }
 
-  override fun surfaceCreated(p0: SurfaceHolder) {
-    // do nothing
+  // Last preview weight passed to refit(). Only read/written from whichever thread the UI calls
+  // refit() on (Compose's main thread via SideEffect), so no synchronization needed.
+  private var previousWeight: Float = 1.0f
+
+  /**
+   * Called by the UI on every preview-weight change (e.g. from a Compose SideEffect over an
+   * animateFloatAsState value). When the transition crosses one of [REFIT_THRESHOLDS] or settles
+   * at an endpoint (0.0 / 1.0), the renderer is asked to re-fit its output to the current view
+   * bounds — that's a swapchain rebuild for Vulkan and a glViewport for OpenGL. Intermediate
+   * animation ticks are filtered out here so the JNI layer only sees the values worth reacting to.
+   *
+   * @return true if this transition actually triggered a native refit.
+   */
+  fun refit(weight: Float): Boolean {
+    val triggered = shouldRefit(previousWeight, weight)
+    previousWeight = weight
+    if (triggered) {
+      nativeRefit()
+    }
+    return triggered
   }
 
-  override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
-    Log.i(TAG, "Surface changed ${holder.surface}, format $format, width $width, height $height")
-    nativeSetSurface(holder.surface, width, height)
+  override fun onSurfaceTextureAvailable(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
+    Log.i(TAG, "Surface texture available, width $width, height $height")
+    surface = Surface(surfaceTexture).also { nativeSetSurface(it, width, height) }
   }
 
-  override fun surfaceDestroyed(p0: SurfaceHolder) {
+  override fun onSurfaceTextureSizeChanged(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
+    Log.i(TAG, "Surface texture size changed, width $width, height $height")
+    nativeSetSurface(surface, width, height)
+  }
+
+  override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
     nativeSetSurface(null, 0, 0)
+    surface?.release()
+    surface = null
+    return true
+  }
+
+  override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {
+    // do nothing
   }
 
   fun destroy() {
@@ -60,6 +90,8 @@ class CoreEngine(
     rotationDegrees: Int,
     backCamera: Boolean
   )
+
+  private external fun nativeRefit()
 
   private external fun nativeDestroy()
 
@@ -109,6 +141,23 @@ class CoreEngine(
 
   private companion object {
     private const val TAG = "DzCoreKotlin"
+
+    // Weight values at which the renderer should re-fit (Vulkan rebuilds its swapchain, OpenGL
+    // runs glViewport). Crossings of these thresholds — plus endpoint settlement at 0.0 / 1.0 —
+    // are the only events forwarded to JNI. Intermediate animation ticks are dropped client-side
+    // so the native layer doesn't have to track previous values or implement crossing detection.
+    private val REFIT_THRESHOLDS = floatArrayOf(0.1f, 0.5f)
+
+    private fun shouldRefit(prev: Float, curr: Float): Boolean {
+      for (threshold in REFIT_THRESHOLDS) {
+        val crossedUp = prev < threshold && curr >= threshold
+        val crossedDown = prev > threshold && curr <= threshold
+        if (crossedUp || crossedDown) return true
+      }
+      // Endpoint settlement: a transition INTO exactly 0.0 or 1.0 means the animation just ended,
+      // so the renderer needs one final re-fit to match the rested view size.
+      return (curr == 0.0f && prev != 0.0f) || (curr == 1.0f && prev != 1.0f)
+    }
 
     init {
       System.loadLibrary("native-engine")

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -163,9 +163,13 @@ class CoreEngine(
         val crossedDown = prev > threshold && curr <= threshold
         if (crossedUp || crossedDown) return true
       }
-      // Endpoint settlement: a transition INTO exactly 0.0 or 1.0 means the animation just ended,
-      // so the renderer needs one final re-fit to match the rested view size.
-      return (curr == 0.0f && prev != 0.0f) || (curr == 1.0f && prev != 1.0f)
+      // Endpoint settlement: detect transitions INTO the rest region rather than equality with
+      // exactly 0f / 1f. animateFloatAsState with tween lands precisely on the target today, but
+      // spring or other animation specs can overshoot or settle slightly past — using <= 0f /
+      // >= 1f keeps the final refit reliable across animation-spec changes.
+      val settledAtZero = curr <= 0.0f && prev > 0.0f
+      val settledAtOne = curr >= 1.0f && prev < 1.0f
+      return settledAtZero || settledAtOne
     }
 
     init {

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -74,6 +74,12 @@ class CoreEngine(
     nativeSetSurface(null, 0, 0)
     surface?.release()
     surface = null
+    // Drop the TextureView reference (the setter also detaches our listener) so a destroyed view
+    // can be GC'd along with its Context. Guard with an identity check so an unrelated callback
+    // from a stale SurfaceTexture wouldn't accidentally null out a freshly-attached TextureView.
+    if (textureView?.surfaceTexture === surfaceTexture) {
+      textureView = null
+    }
     return true
   }
 

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -39,9 +39,12 @@ void BaseRenderer::updateWindowSize(int width, int height) {
     needsSchedule = !resizeTaskScheduled;
     resizeTaskScheduled = true;
   }
-  if (!needsSchedule) {
-    return;
+  if (needsSchedule) {
+    scheduleApplyPendingViewportSize();
   }
+}
+
+void BaseRenderer::scheduleApplyPendingViewportSize() {
   renderThread->scheduleTask([this] {
     int width;
     int height;
@@ -92,9 +95,10 @@ void BaseRenderer::updateWindowSize(int width, int height) {
     }
 
     if (reschedule) {
-      renderThread->scheduleTask([this] {
-        updateWindowSize(pendingViewportWidth, pendingViewportHeight);
-      });
+      // Re-post the same consumer body — NOT the producer entry. The next iteration will read
+      // pendingViewport* fresh under resizeMutex, so we can't ship a stale snapshot of pending
+      // dims and we can't clobber a newer producer write by re-entering through updateWindowSize.
+      scheduleApplyPendingViewportSize();
     }
   });
 }

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -31,17 +31,39 @@ void BaseRenderer::setWindow(ANativeWindow *window) {
 }
 
 void BaseRenderer::updateWindowSize(int width, int height) {
-  renderThread->scheduleTask([this, width, height] {
-    // calculate MVP on CPU, if we would know it will be updated more often -
-    // of course better move matrix calculation to GPU
+  // Publish the latest requested size unconditionally. If a task is already in flight, it will
+  // pick this value up when it runs — no point queueing another full swapchain rebuild behind it.
+  pendingViewportWidth.store(width, std::memory_order_relaxed);
+  pendingViewportHeight.store(height, std::memory_order_relaxed);
+  bool expected = false;
+  if (!resizeTaskScheduled.compare_exchange_strong(expected, true,
+                                                   std::memory_order_acq_rel)) {
+    return;
+  }
+  renderThread->scheduleTask([this] {
+    // Clear the scheduled flag BEFORE reading the pending size: any producer that runs after this
+    // point will schedule a fresh task with the newer dimensions.
+    resizeTaskScheduled.store(false, std::memory_order_release);
+    const int width = pendingViewportWidth.load(std::memory_order_relaxed);
+    const int height = pendingViewportHeight.load(std::memory_order_relaxed);
     if (viewportWidth != width || viewportHeight != height) {
       viewportWidth = width;
       viewportHeight = height;
       LOGI("Update window size, width=%i, height=%i", viewportWidth, viewportHeight);
+      // Per-tick lightweight hook — OpenGL's glViewport must run on every layout tick or the
+      // aspect ratio of rendered content goes wrong during a resize. Heavy size-driven work
+      // (Vulkan swapchain rebuild) is gated by onRefit() instead.
       onWindowSizeUpdated(width, height);
     }
-    // update MVP in any case to cover the use-case of brining app to background and back
     updateMvp();
+  });
+}
+
+void BaseRenderer::refit() {
+  renderThread->scheduleTask([this] {
+    if (viewportWidth > 0 && viewportHeight > 0) {
+      onRefit(viewportWidth, viewportHeight);
+    }
   });
 }
 

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -43,48 +43,58 @@ void BaseRenderer::updateWindowSize(int width, int height) {
     return;
   }
   renderThread->scheduleTask([this] {
-    // Keep resizeTaskScheduled = true for the whole duration of this task so producers running
-    // in parallel can't schedule a second task — they'll instead just update pending dims, which
-    // we'll pick up on the next iteration of this loop. The slot is released only after we
-    // observe a tick where pending == applied, guaranteeing no producer's latest size is lost.
-    while (true) {
-      int width;
-      int height;
-      bool sizeChanged;
-      {
-        // Single critical section that covers the read of pending dims, the compare against
-        // applied dims, and (when we proceed) the write of applied dims. Keeping the compare
-        // and the write under the same lock as the producer's pending-store means we can't
-        // straddle a producer update — either the producer's new pending lands BEFORE our
-        // compare (we apply it this iteration) or AFTER our scheduled-flag clear (it schedules
-        // a fresh task). The heavy work below runs unlocked so producers stay responsive.
-        std::lock_guard<std::mutex> lock(resizeMutex);
-        width = pendingViewportWidth;
-        height = pendingViewportHeight;
-        sizeChanged = (viewportWidth != width || viewportHeight != height);
-        if (!sizeChanged) {
-          resizeTaskScheduled = false;
-        } else {
-          viewportWidth = width;
-          viewportHeight = height;
-        }
+    int width;
+    int height;
+    bool sizeChanged;
+    {
+      // Process at most one pending size per scheduled task so the render thread yields back
+      // to the looper between resize ticks instead of draining an arbitrarily long animation
+      // inside a single callback. Producers still coalesce naturally by updating the pending
+      // dimensions under the same lock.
+      std::lock_guard<std::mutex> lock(resizeMutex);
+      width = pendingViewportWidth;
+      height = pendingViewportHeight;
+      sizeChanged = (viewportWidth != width || viewportHeight != height);
+      if (sizeChanged) {
+        viewportWidth = width;
+        viewportHeight = height;
       }
-      if (!sizeChanged) {
-        // Refresh MVP on the way out even when the size was unchanged: producers (e.g. surface
-        // re-creation on background → foreground) can re-fire updateWindowSize with the same
-        // dimensions, and the rest of the renderer relies on the MVP being current.
-        updateMvp();
-        return;
-      }
+    }
+
+    if (!sizeChanged) {
+      // Refresh MVP even when the size was unchanged: producers (e.g. surface re-creation on
+      // background → foreground) can re-fire updateWindowSize with the same dimensions, and the
+      // rest of the renderer relies on the MVP being current.
+      updateMvp();
+    } else {
       LOGI("Update window size, width=%i, height=%i", width, height);
       // Per-tick lightweight hook — OpenGL's glViewport must run on every layout tick or the
       // aspect ratio of rendered content goes wrong during a resize. Heavy size-driven work
       // (Vulkan swapchain rebuild) is gated by onRefit() instead.
       onWindowSizeUpdated(width, height);
-      // Refresh MVP for this applied size before the next iteration. Otherwise the projection /
-      // aspect ratio would stay stale across the animation: OpenGL's glViewport would track the
-      // current viewport but the uMvpMatrix (and Vulkan's UBO) would not.
+      // Refresh MVP for this applied size before yielding back to the looper. Otherwise the
+      // projection / aspect ratio would stay stale across the animation: OpenGL's glViewport
+      // would track the current viewport but the uMvpMatrix (and Vulkan's UBO) would not.
       updateMvp();
+    }
+
+    bool reschedule = false;
+    {
+      // If a producer updated the pending size while this task was running, keep the scheduled
+      // slot claimed and post a fresh task so the looper can interleave other render-thread work
+      // before we apply the newer size. Otherwise release the slot.
+      std::lock_guard<std::mutex> lock(resizeMutex);
+      if (pendingViewportWidth != viewportWidth || pendingViewportHeight != viewportHeight) {
+        reschedule = true;
+      } else {
+        resizeTaskScheduled = false;
+      }
+    }
+
+    if (reschedule) {
+      renderThread->scheduleTask([this] {
+        updateWindowSize(pendingViewportWidth, pendingViewportHeight);
+      });
     }
   });
 }

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -31,21 +31,31 @@ void BaseRenderer::setWindow(ANativeWindow *window) {
 }
 
 void BaseRenderer::updateWindowSize(int width, int height) {
-  // Publish the latest requested size unconditionally. If a task is already in flight, it will
-  // pick this value up when it runs — no point queueing another full swapchain rebuild behind it.
-  pendingViewportWidth.store(width, std::memory_order_relaxed);
-  pendingViewportHeight.store(height, std::memory_order_relaxed);
-  bool expected = false;
-  if (!resizeTaskScheduled.compare_exchange_strong(expected, true,
-                                                   std::memory_order_acq_rel)) {
+  // Coalesce: stash the latest requested size and only schedule a render-thread task if one is
+  // not already in flight. The mutex covers both pending dimensions and the scheduled flag so
+  // we never observe a torn (width, height) pair or race on the schedule decision.
+  bool needsSchedule;
+  {
+    std::lock_guard<std::mutex> lock(resizeMutex);
+    pendingViewportWidth = width;
+    pendingViewportHeight = height;
+    needsSchedule = !resizeTaskScheduled;
+    resizeTaskScheduled = true;
+  }
+  if (!needsSchedule) {
     return;
   }
   renderThread->scheduleTask([this] {
-    // Clear the scheduled flag BEFORE reading the pending size: any producer that runs after this
-    // point will schedule a fresh task with the newer dimensions.
-    resizeTaskScheduled.store(false, std::memory_order_release);
-    const int width = pendingViewportWidth.load(std::memory_order_relaxed);
-    const int height = pendingViewportHeight.load(std::memory_order_relaxed);
+    int width;
+    int height;
+    {
+      // Clear the scheduled flag BEFORE we go on to call onWindowSizeUpdated: any producer that
+      // runs after this point will schedule a fresh task with the newer dimensions.
+      std::lock_guard<std::mutex> lock(resizeMutex);
+      resizeTaskScheduled = false;
+      width = pendingViewportWidth;
+      height = pendingViewportHeight;
+    }
     if (viewportWidth != width || viewportHeight != height) {
       viewportWidth = width;
       viewportHeight = height;

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -59,8 +59,8 @@ void BaseRenderer::updateWindowSize(int width, int height) {
       // aspect ratio of rendered content goes wrong during a resize. Heavy size-driven work
       // (Vulkan swapchain rebuild) is gated by onRefit() instead.
       onWindowSizeUpdated(width, height);
+      updateMvp();
     }
-    updateMvp();
   });
 }
 
@@ -88,6 +88,9 @@ void BaseRenderer::resetWindow() {
 }
 
 void BaseRenderer::updateMvp() {
+  if (viewportWidth <= 0 || viewportHeight <= 0) {
+    return;
+  }
   float viewportRatio =
           static_cast<float>(viewportWidth) / static_cast<float>(viewportHeight);
   float ratio = viewportRatio * bufferImageRatio;

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -51,6 +51,12 @@ void BaseRenderer::updateWindowSize(int width, int height) {
       int width;
       int height;
       {
+        // Single critical section that covers the read of pending dims, the compare against
+        // applied dims, and (when we proceed) the write of applied dims. Keeping the compare
+        // and the write under the same lock as the producer's pending-store means we can't
+        // straddle a producer update — either the producer's new pending lands BEFORE our
+        // compare (we apply it this iteration) or AFTER our scheduled-flag clear (it schedules
+        // a fresh task). The heavy work below runs unlocked so producers stay responsive.
         std::lock_guard<std::mutex> lock(resizeMutex);
         width = pendingViewportWidth;
         height = pendingViewportHeight;
@@ -58,9 +64,9 @@ void BaseRenderer::updateWindowSize(int width, int height) {
           resizeTaskScheduled = false;
           return;
         }
+        viewportWidth = width;
+        viewportHeight = height;
       }
-      viewportWidth = width;
-      viewportHeight = height;
       LOGI("Update window size, width=%i, height=%i", viewportWidth, viewportHeight);
       // Per-tick lightweight hook — OpenGL's glViewport must run on every layout tick or the
       // aspect ratio of rendered content goes wrong during a resize. Heavy size-driven work

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -43,15 +43,22 @@ void BaseRenderer::updateWindowSize(int width, int height) {
     return;
   }
   renderThread->scheduleTask([this] {
-    int width;
-    int height;
-    {
-      std::lock_guard<std::mutex> lock(resizeMutex);
-      resizeTaskScheduled = false;
-      width = pendingViewportWidth;
-      height = pendingViewportHeight;
-    }
-    if (viewportWidth != width || viewportHeight != height) {
+    // Keep resizeTaskScheduled = true for the whole duration of this task so producers running
+    // in parallel can't schedule a second task — they'll instead just update pending dims, which
+    // we'll pick up on the next iteration of this loop. The slot is released only after we
+    // observe a tick where pending == applied, guaranteeing no producer's latest size is lost.
+    while (true) {
+      int width;
+      int height;
+      {
+        std::lock_guard<std::mutex> lock(resizeMutex);
+        width = pendingViewportWidth;
+        height = pendingViewportHeight;
+        if (viewportWidth == width && viewportHeight == height) {
+          resizeTaskScheduled = false;
+          return;
+        }
+      }
       viewportWidth = width;
       viewportHeight = height;
       LOGI("Update window size, width=%i, height=%i", viewportWidth, viewportHeight);

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -50,6 +50,7 @@ void BaseRenderer::updateWindowSize(int width, int height) {
     while (true) {
       int width;
       int height;
+      bool sizeChanged;
       {
         // Single critical section that covers the read of pending dims, the compare against
         // applied dims, and (when we proceed) the write of applied dims. Keeping the compare
@@ -60,19 +61,26 @@ void BaseRenderer::updateWindowSize(int width, int height) {
         std::lock_guard<std::mutex> lock(resizeMutex);
         width = pendingViewportWidth;
         height = pendingViewportHeight;
-        if (viewportWidth == width && viewportHeight == height) {
+        sizeChanged = (viewportWidth != width || viewportHeight != height);
+        if (!sizeChanged) {
           resizeTaskScheduled = false;
-          return;
+        } else {
+          viewportWidth = width;
+          viewportHeight = height;
         }
-        viewportWidth = width;
-        viewportHeight = height;
       }
-      LOGI("Update window size, width=%i, height=%i", viewportWidth, viewportHeight);
+      if (!sizeChanged) {
+        // Refresh MVP on the way out even when the size was unchanged: producers (e.g. surface
+        // re-creation on background → foreground) can re-fire updateWindowSize with the same
+        // dimensions, and the rest of the renderer relies on the MVP being current.
+        updateMvp();
+        return;
+      }
+      LOGI("Update window size, width=%i, height=%i", width, height);
       // Per-tick lightweight hook — OpenGL's glViewport must run on every layout tick or the
       // aspect ratio of rendered content goes wrong during a resize. Heavy size-driven work
       // (Vulkan swapchain rebuild) is gated by onRefit() instead.
       onWindowSizeUpdated(width, height);
-      updateMvp();
     }
   });
 }

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -81,6 +81,10 @@ void BaseRenderer::updateWindowSize(int width, int height) {
       // aspect ratio of rendered content goes wrong during a resize. Heavy size-driven work
       // (Vulkan swapchain rebuild) is gated by onRefit() instead.
       onWindowSizeUpdated(width, height);
+      // Refresh MVP for this applied size before the next iteration. Otherwise the projection /
+      // aspect ratio would stay stale across the animation: OpenGL's glViewport would track the
+      // current viewport but the uMvpMatrix (and Vulkan's UBO) would not.
+      updateMvp();
     }
   });
 }

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -31,9 +31,6 @@ void BaseRenderer::setWindow(ANativeWindow *window) {
 }
 
 void BaseRenderer::updateWindowSize(int width, int height) {
-  // Coalesce: stash the latest requested size and only schedule a render-thread task if one is
-  // not already in flight. The mutex covers both pending dimensions and the scheduled flag so
-  // we never observe a torn (width, height) pair or race on the schedule decision.
   bool needsSchedule;
   {
     std::lock_guard<std::mutex> lock(resizeMutex);
@@ -49,8 +46,6 @@ void BaseRenderer::updateWindowSize(int width, int height) {
     int width;
     int height;
     {
-      // Clear the scheduled flag BEFORE we go on to call onWindowSizeUpdated: any producer that
-      // runs after this point will schedule a fresh task with the newer dimensions.
       std::lock_guard<std::mutex> lock(resizeMutex);
       resizeTaskScheduled = false;
       width = pendingViewportWidth;

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -50,10 +50,6 @@ void BaseRenderer::scheduleApplyPendingViewportSize() {
     int height;
     bool sizeChanged;
     {
-      // Process at most one pending size per scheduled task so the render thread yields back
-      // to the looper between resize ticks instead of draining an arbitrarily long animation
-      // inside a single callback. Producers still coalesce naturally by updating the pending
-      // dimensions under the same lock.
       std::lock_guard<std::mutex> lock(resizeMutex);
       width = pendingViewportWidth;
       height = pendingViewportHeight;
@@ -64,28 +60,14 @@ void BaseRenderer::scheduleApplyPendingViewportSize() {
       }
     }
 
-    if (!sizeChanged) {
-      // Refresh MVP even when the size was unchanged: producers (e.g. surface re-creation on
-      // background → foreground) can re-fire updateWindowSize with the same dimensions, and the
-      // rest of the renderer relies on the MVP being current.
-      updateMvp();
-    } else {
+    if (sizeChanged) {
       LOGI("Update window size, width=%i, height=%i", width, height);
-      // Per-tick lightweight hook — OpenGL's glViewport must run on every layout tick or the
-      // aspect ratio of rendered content goes wrong during a resize. Heavy size-driven work
-      // (Vulkan swapchain rebuild) is gated by onRefit() instead.
       onWindowSizeUpdated(width, height);
-      // Refresh MVP for this applied size before yielding back to the looper. Otherwise the
-      // projection / aspect ratio would stay stale across the animation: OpenGL's glViewport
-      // would track the current viewport but the uMvpMatrix (and Vulkan's UBO) would not.
-      updateMvp();
     }
+    updateMvp();
 
     bool reschedule = false;
     {
-      // If a producer updated the pending size while this task was running, keep the scheduled
-      // slot claimed and post a fresh task so the looper can interleave other render-thread work
-      // before we apply the newer size. Otherwise release the slot.
       std::lock_guard<std::mutex> lock(resizeMutex);
       if (pendingViewportWidth != viewportWidth || pendingViewportHeight != viewportHeight) {
         reschedule = true;
@@ -95,9 +77,6 @@ void BaseRenderer::scheduleApplyPendingViewportSize() {
     }
 
     if (reschedule) {
-      // Re-post the same consumer body — NOT the producer entry. The next iteration will read
-      // pendingViewport* fresh under resizeMutex, so we can't ship a stale snapshot of pending
-      // dims and we can't clobber a newer producer write by re-entering through updateWindowSize.
       scheduleApplyPendingViewportSize();
     }
   });
@@ -127,6 +106,8 @@ void BaseRenderer::resetWindow() {
 }
 
 void BaseRenderer::updateMvp() {
+  // Guard against 0-dim viewports — TextureView can fire callbacks with 0 height when weights
+  // animate to 0, and that would feed inf/NaN into the projection.
   if (viewportWidth <= 0 || viewportHeight <= 0) {
     return;
   }

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -57,9 +57,12 @@ protected:
     virtual void onWindowDestroyed() = 0;
 
     /**
-     * Lightweight per-tick size update. Called from every updateWindowSize task — i.e. once per
-     * surfaceTextureSizeChanged callback. Cheap operations belong here (e.g. OpenGL's glViewport);
-     * expensive ones (e.g. Vulkan swapchain rebuild) should leave this empty and react in onRefit.
+     * Lightweight size update. Called from each scheduled updateWindowSize task on the render
+     * thread, with the LATEST observed dimensions. Note that updateWindowSize coalesces — a burst
+     * of surfaceTextureSizeChanged callbacks collapses into a single task that sees only the most
+     * recent (width, height), so intermediate sizes are skipped by design. Cheap operations
+     * belong here (e.g. OpenGL's glViewport); expensive ones (e.g. Vulkan swapchain rebuild)
+     * should leave this empty and react in onRefit instead.
      */
     virtual void onWindowSizeUpdated(int width, int height) = 0;
 

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <atomic>
-
 #include <android/choreographer.h>
 #include <android/hardware_buffer.h>
 #include <android/native_window.h>
@@ -111,13 +109,14 @@ private:
     std::condition_variable initCondition;
     std::condition_variable destroyCondition;
 
-    // Coalescing state for updateWindowSize: layout animations can fire surfaceChanged at ~60Hz,
-    // and a queued backlog of full swapchain rebuilds is what makes Vulkan resize feel sluggish.
-    // Producers stash the latest requested size and only schedule a render-thread task if one is
-    // not already in flight; the task reads whichever size is current when it runs.
-    std::atomic<int> pendingViewportWidth{-1};
-    std::atomic<int> pendingViewportHeight{-1};
-    std::atomic<bool> resizeTaskScheduled{false};
+    // Coalescing state for updateWindowSize: layout animations can fire surfaceTextureSizeChanged
+    // at ~60Hz, and a queued backlog of per-tick work is what would make resize feel sluggish.
+    // Producers stash the latest requested size under resizeMutex and only schedule a render-thread
+    // task if one is not already in flight; the task reads whichever size is current when it runs.
+    std::mutex resizeMutex;
+    int pendingViewportWidth = -1;
+    int pendingViewportHeight = -1;
+    bool resizeTaskScheduled = false;
 };
 
 } // namespace android

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -28,16 +28,8 @@ public:
     void updateWindowSize(int width, int height);
 
     /**
-     * Re-fit the renderer's output to the current viewport size at a UI-driven key frame
-     * (threshold crossings, endpoint settlement). The filtering of which moments count as "key"
-     * lives on the Kotlin side, so every call into this method is expected to be meaningful.
-     *
-     * Drives the renderer's onRefit() hook on the render thread — Vulkan rebuilds its swapchain
-     * there; OpenGL doesn't override it because its per-tick glViewport in onWindowSizeUpdated
-     * already keeps the rasterization area in sync.
-     *
-     * Note: onWindowSizeUpdated is the SEPARATE per-tick hook that fires on every
-     * updateWindowSize task — this method does not drive that one.
+     * Called at UI-driven key frames; runs the renderer's onRefit() on the render thread.
+     * Vulkan rebuilds its swapchain there; OpenGL keeps the default no-op.
      */
     void refit();
 
@@ -56,20 +48,11 @@ protected:
 
     virtual void onWindowDestroyed() = 0;
 
-    /**
-     * Lightweight size update. Called from each scheduled updateWindowSize task on the render
-     * thread, with the LATEST observed dimensions. Note that updateWindowSize coalesces — a burst
-     * of surfaceTextureSizeChanged callbacks collapses into a single task that sees only the most
-     * recent (width, height), so intermediate sizes are skipped by design. Cheap operations
-     * belong here (e.g. OpenGL's glViewport); expensive ones (e.g. Vulkan swapchain rebuild)
-     * should leave this empty and react in onRefit instead.
-     */
+    // Per-tick lightweight hook (e.g. OpenGL glViewport). Heavy size-driven work belongs in
+    // onRefit instead.
     virtual void onWindowSizeUpdated(int width, int height) = 0;
 
-    /**
-     * Heavy refit hook, fired only at UI-driven key frames (see refit()). Default is no-op;
-     * Vulkan overrides to rebuild the swapchain at the current viewport size.
-     */
+    // Fires only at UI-driven key frames via refit().
     virtual void onRefit(int width, int height) {}
 
     virtual void hwBufferToTexture(AHardwareBuffer *buffer) = 0;
@@ -104,15 +87,9 @@ private:
      */
     void updateMvp();
 
-    /**
-     * Schedule the render-thread consumer task that drains the latest pendingViewport* into
-     * the applied viewportWidth/Height. Used by both updateWindowSize (initial schedule) and
-     * the consumer task itself (re-schedule when a newer pending value arrived mid-task) so the
-     * consumer body always re-reads pending under resizeMutex — never with a stale snapshot,
-     * and never via the producer entry that would clobber pending.
-     */
+    // Render-thread consumer that drains pendingViewport* into applied viewportWidth/Height.
+    // Re-scheduled by the task itself when newer pending values arrived mid-task.
     void scheduleApplyPendingViewportSize();
-
 
     float bufferImageRatio = 1.0f;
     int rotationDegrees = 0;
@@ -123,10 +100,7 @@ private:
     std::condition_variable initCondition;
     std::condition_variable destroyCondition;
 
-    // Coalescing state for updateWindowSize: layout animations can fire surfaceTextureSizeChanged
-    // at ~60Hz, and a queued backlog of per-tick work is what would make resize feel sluggish.
-    // Producers stash the latest requested size under resizeMutex and only schedule a render-thread
-    // task if one is not already in flight; the task reads whichever size is current when it runs.
+    // Coalescing state for updateWindowSize; protected by resizeMutex.
     std::mutex resizeMutex;
     int pendingViewportWidth = -1;
     int pendingViewportHeight = -1;

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -104,6 +104,15 @@ private:
      */
     void updateMvp();
 
+    /**
+     * Schedule the render-thread consumer task that drains the latest pendingViewport* into
+     * the applied viewportWidth/Height. Used by both updateWindowSize (initial schedule) and
+     * the consumer task itself (re-schedule when a newer pending value arrived mid-task) so the
+     * consumer body always re-reads pending under resizeMutex — never with a stale snapshot,
+     * and never via the producer entry that would clobber pending.
+     */
+    void scheduleApplyPendingViewportSize();
+
 
     float bufferImageRatio = 1.0f;
     int rotationDegrees = 0;

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include <android/choreographer.h>
 #include <android/hardware_buffer.h>
 #include <android/native_window.h>
@@ -27,6 +29,18 @@ public:
 
     void updateWindowSize(int width, int height);
 
+    /**
+     * Re-fit the renderer's output to the current viewport size — Vulkan rebuilds its swapchain,
+     * OpenGL runs glViewport. Called by the UI at key points of a resize animation (threshold
+     * crossings, endpoint settlement); the filtering of which moments count as "key" lives on
+     * the Kotlin side, so every call into this method is expected to be meaningful.
+     *
+     * This is intentionally the ONLY path that drives onWindowSizeUpdated in concrete renderers.
+     * Per-tick layout changes from surfaceTextureSizeChanged only update viewport bookkeeping
+     * and the MVP, never fire the renderer-specific hook.
+     */
+    void refit();
+
     void resetWindow();
 
     /**
@@ -42,7 +56,18 @@ protected:
 
     virtual void onWindowDestroyed() = 0;
 
+    /**
+     * Lightweight per-tick size update. Called from every updateWindowSize task — i.e. once per
+     * surfaceTextureSizeChanged callback. Cheap operations belong here (e.g. OpenGL's glViewport);
+     * expensive ones (e.g. Vulkan swapchain rebuild) should leave this empty and react in onRefit.
+     */
     virtual void onWindowSizeUpdated(int width, int height) = 0;
+
+    /**
+     * Heavy refit hook, fired only at UI-driven key frames (see refit()). Default is no-op;
+     * Vulkan overrides to rebuild the swapchain at the current viewport size.
+     */
+    virtual void onRefit(int width, int height) {}
 
     virtual void hwBufferToTexture(AHardwareBuffer *buffer) = 0;
 
@@ -63,6 +88,7 @@ protected:
     int viewportHeight = -1;
     glm::mat4 mvp;
 
+
     /**
      * The mutex needed as worker camera thread produces buffers while render thread consumes them.
      */
@@ -75,6 +101,7 @@ private:
      */
     void updateMvp();
 
+
     float bufferImageRatio = 1.0f;
     int rotationDegrees = 0;
     bool backCamera = false;
@@ -83,6 +110,14 @@ private:
     std::mutex mutex;
     std::condition_variable initCondition;
     std::condition_variable destroyCondition;
+
+    // Coalescing state for updateWindowSize: layout animations can fire surfaceChanged at ~60Hz,
+    // and a queued backlog of full swapchain rebuilds is what makes Vulkan resize feel sluggish.
+    // Producers stash the latest requested size and only schedule a render-thread task if one is
+    // not already in flight; the task reads whichever size is current when it runs.
+    std::atomic<int> pendingViewportWidth{-1};
+    std::atomic<int> pendingViewportHeight{-1};
+    std::atomic<bool> resizeTaskScheduled{false};
 };
 
 } // namespace android

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -28,14 +28,16 @@ public:
     void updateWindowSize(int width, int height);
 
     /**
-     * Re-fit the renderer's output to the current viewport size — Vulkan rebuilds its swapchain,
-     * OpenGL runs glViewport. Called by the UI at key points of a resize animation (threshold
-     * crossings, endpoint settlement); the filtering of which moments count as "key" lives on
-     * the Kotlin side, so every call into this method is expected to be meaningful.
+     * Re-fit the renderer's output to the current viewport size at a UI-driven key frame
+     * (threshold crossings, endpoint settlement). The filtering of which moments count as "key"
+     * lives on the Kotlin side, so every call into this method is expected to be meaningful.
      *
-     * This is intentionally the ONLY path that drives onWindowSizeUpdated in concrete renderers.
-     * Per-tick layout changes from surfaceTextureSizeChanged only update viewport bookkeeping
-     * and the MVP, never fire the renderer-specific hook.
+     * Drives the renderer's onRefit() hook on the render thread — Vulkan rebuilds its swapchain
+     * there; OpenGL doesn't override it because its per-tick glViewport in onWindowSizeUpdated
+     * already keeps the rasterization area in sync.
+     *
+     * Note: onWindowSizeUpdated is the SEPARATE per-tick hook that fires on every
+     * updateWindowSize task — this method does not drive that one.
      */
     void refit();
 

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -74,7 +74,7 @@ void CoreEngine::nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint 
 /** called from worker thread **/
 void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBuffer> &buffer,
                                        jni::jint rotationDegrees, jni::jboolean backCamera) {
-  std::lock_guard<std::mutex> lock(coreEngineMutex);
+  std::unique_lock<std::mutex> lock(coreEngineMutex);
   if (!renderer) {
     return;
   }
@@ -82,8 +82,17 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
   AHardwareBuffer_Desc cameraBufferDescription;
   AHardwareBuffer_describe(cameraBuffer, &cameraBufferDescription);
   if (cameraBufferDescription.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) {
+    // Fast path — processCameraFrame just schedules a render-thread task and returns. Keep the
+    // mutex held; it costs ~nothing.
     renderer->processCameraFrame(cameraBuffer, rotationDegrees, backCamera);
-  } else {
+    return;
+  }
+  // CPU fallback. The hot work below (two AHardwareBuffer_locks + memcpy + two unlocks) is in
+  // the milliseconds range on devices that hit this branch and would otherwise block main-thread
+  // JNI calls (nativeUpdateWindowSize during a resize animation, nativeRefit, nativeSetSurface)
+  // behind us. Drop the mutex around it, retaining gpuBuffer with our own +1 reference so that
+  // a concurrent nativeDestroy can release its ref without the underlying buffer disappearing.
+  if (!gpuBuffer) {
     AHardwareBuffer_Desc gpuBufferDescription {
             .width = cameraBufferDescription.width,
             .height = cameraBufferDescription.height,
@@ -91,20 +100,30 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
             .format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM,
             .usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE | AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER,
     };
-    if (!gpuBuffer) {
-      int res = AHardwareBuffer_allocate(&gpuBufferDescription, &gpuBuffer);
-      LOGI("HW buffer from camera does not support AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE.");
-      LOGI("Allocating GPU HW buffer manually. Result: %d", res);
-    }
-    void* gpuData = nullptr;
-    void* cpuData = nullptr;
-    AHardwareBuffer_lock(cameraBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &cpuData);
-    AHardwareBuffer_lock(gpuBuffer, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1, nullptr, &gpuData);
-    memcpy(gpuData, cpuData, cameraBufferDescription.height * cameraBufferDescription.width * 4);
-    AHardwareBuffer_unlock(cameraBuffer, nullptr);
-    AHardwareBuffer_unlock(gpuBuffer, nullptr);
-    renderer->processCameraFrame(gpuBuffer, rotationDegrees, backCamera);
+    int res = AHardwareBuffer_allocate(&gpuBufferDescription, &gpuBuffer);
+    LOGI("HW buffer from camera does not support AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE.");
+    LOGI("Allocating GPU HW buffer manually. Result: %d", res);
   }
+  AHardwareBuffer *localGpuBuffer = gpuBuffer;
+  AHardwareBuffer_acquire(localGpuBuffer);
+  lock.unlock();
+
+  void* gpuData = nullptr;
+  void* cpuData = nullptr;
+  AHardwareBuffer_lock(cameraBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &cpuData);
+  AHardwareBuffer_lock(localGpuBuffer, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, -1, nullptr, &gpuData);
+  memcpy(gpuData, cpuData, cameraBufferDescription.height * cameraBufferDescription.width * 4);
+  AHardwareBuffer_unlock(cameraBuffer, nullptr);
+  AHardwareBuffer_unlock(localGpuBuffer, nullptr);
+
+  lock.lock();
+  // nativeDestroy may have fired during the unlocked window. If so, drop this frame — the
+  // renderer is gone and processCameraFrame would crash. Our extra ref keeps localGpuBuffer
+  // alive long enough to release it cleanly below.
+  if (renderer) {
+    renderer->processCameraFrame(localGpuBuffer, rotationDegrees, backCamera);
+  }
+  AHardwareBuffer_release(localGpuBuffer);
 }
 
 void CoreEngine::nativeRefit(JNIEnv &env) {

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -73,6 +73,12 @@ void CoreEngine::nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint 
 /** called from worker thread **/
 void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBuffer> &buffer,
                                        jni::jint rotationDegrees, jni::jboolean backCamera) {
+  // Camera worker can fire after nativeDestroy() has reset the renderer. Skip the frame rather
+  // than deref a moved-from unique_ptr — this is not race-free against a concurrent destroy
+  // (would need a mutex for that) but covers the common ordering where destroy completes first.
+  if (!renderer) {
+    return;
+  }
   auto cameraBuffer = AHardwareBuffer_fromHardwareBuffer(&env, jni::Unwrap(*buffer.get()));
   AHardwareBuffer_Desc cameraBufferDescription;
   AHardwareBuffer_describe(cameraBuffer, &cameraBufferDescription);

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -117,7 +117,23 @@ void CoreEngine::nativeRefit(JNIEnv &env) {
 void CoreEngine::nativeDestroy(JNIEnv &env) {
   std::lock_guard<std::mutex> lock(coreEngineMutex);
   LOGI("Core engine destroy started");
+
+  if (renderer && aNativeWindow != nullptr) {
+    renderer->resetWindow();
+  }
+
   renderer.reset();
+
+  if (aNativeWindow != nullptr) {
+    ANativeWindow_release(aNativeWindow);
+    aNativeWindow = nullptr;
+  }
+
+  if (gpuBuffer != nullptr) {
+    AHardwareBuffer_release(gpuBuffer);
+    gpuBuffer = nullptr;
+  }
+
   LOGI("Core engine destroy passed");
 }
 

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -28,12 +28,9 @@ void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surfa
                                   jni::jint width, jni::jint height) {
   std::lock_guard<std::mutex> lock(coreEngineMutex);
   if (surface.get() != nullptr) {
-    // ANativeWindow_fromSurface returns a NEW strong reference (+1 on the refcount); we own it
-    // and must release it ourselves. Do NOT also call ANativeWindow_acquire — that would leak.
+    // ANativeWindow_fromSurface returns +1 ref; we own it.
     auto *nativeWindow = ANativeWindow_fromSurface(&env, jni::Unwrap(*surface.get()));
     if (nativeWindow == nullptr) {
-      // fromSurface can fail (e.g. surface already invalidated). Bail before driving any
-      // render-thread size work without a valid native window.
       LOGE("ANativeWindow_fromSurface returned null; skipping surface configuration");
       return;
     }
@@ -46,7 +43,6 @@ void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surfa
         renderer->setWindow(nativeWindow);
       }
     } else {
-      // Same underlying window — drop the duplicate ref returned by fromSurface.
       ANativeWindow_release(nativeWindow);
     }
     if (renderer) {
@@ -82,16 +78,11 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
   AHardwareBuffer_Desc cameraBufferDescription;
   AHardwareBuffer_describe(cameraBuffer, &cameraBufferDescription);
   if (cameraBufferDescription.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) {
-    // Fast path — processCameraFrame just schedules a render-thread task and returns. Keep the
-    // mutex held; it costs ~nothing.
     renderer->processCameraFrame(cameraBuffer, rotationDegrees, backCamera);
     return;
   }
-  // CPU fallback. The hot work below (two AHardwareBuffer_locks + memcpy + two unlocks) is in
-  // the milliseconds range on devices that hit this branch and would otherwise block main-thread
-  // JNI calls (nativeUpdateWindowSize during a resize animation, nativeRefit, nativeSetSurface)
-  // behind us. Drop the mutex around it, retaining gpuBuffer with our own +1 reference so that
-  // a concurrent nativeDestroy can release its ref without the underlying buffer disappearing.
+  // CPU fallback: drop the mutex around the slow memcpy so main-thread JNI calls aren't blocked
+  // behind it. Hold our own +1 ref on gpuBuffer so a racing nativeDestroy can't free it.
   if (!gpuBuffer) {
     AHardwareBuffer_Desc gpuBufferDescription {
             .width = cameraBufferDescription.width,
@@ -121,9 +112,6 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
   AHardwareBuffer_unlock(localGpuBuffer, nullptr);
 
   lock.lock();
-  // nativeDestroy may have fired during the unlocked window. If so, drop this frame — the
-  // renderer is gone and processCameraFrame would crash. Our extra ref keeps localGpuBuffer
-  // alive long enough to release it cleanly below.
   if (renderer) {
     renderer->processCameraFrame(localGpuBuffer, rotationDegrees, backCamera);
   }

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -30,6 +30,12 @@ void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surfa
     // ANativeWindow_fromSurface returns a NEW strong reference (+1 on the refcount); we own it
     // and must release it ourselves. Do NOT also call ANativeWindow_acquire — that would leak.
     auto *nativeWindow = ANativeWindow_fromSurface(&env, jni::Unwrap(*surface.get()));
+    if (nativeWindow == nullptr) {
+      // fromSurface can fail (e.g. surface already invalidated). Bail before driving any
+      // render-thread size work without a valid native window.
+      LOGE("ANativeWindow_fromSurface returned null; skipping surface configuration");
+      return;
+    }
     if (nativeWindow != aNativeWindow) {
       if (aNativeWindow != nullptr) {
         ANativeWindow_release(aNativeWindow);

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -103,6 +103,10 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
     int res = AHardwareBuffer_allocate(&gpuBufferDescription, &gpuBuffer);
     LOGI("HW buffer from camera does not support AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE.");
     LOGI("Allocating GPU HW buffer manually. Result: %d", res);
+    if (res != 0 || gpuBuffer == nullptr) {
+      LOGI("Failed to allocate GPU HW buffer; dropping frame.");
+      return;
+    }
   }
   AHardwareBuffer *localGpuBuffer = gpuBuffer;
   AHardwareBuffer_acquire(localGpuBuffer);

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -75,6 +75,12 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
   }
 }
 
+void CoreEngine::nativeRefit(JNIEnv &env) {
+  if (renderer) {
+    renderer->refit();
+  }
+}
+
 void CoreEngine::nativeDestroy(JNIEnv &env) {
   LOGI("Core engine destroy started");
   renderer.reset();

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -27,25 +27,39 @@ CoreEngine::~CoreEngine() = default;
 void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surface,
                                   jni::jint width, jni::jint height) {
   if (surface.get() != nullptr) {
+    // ANativeWindow_fromSurface returns a NEW strong reference (+1 on the refcount); we own it
+    // and must release it ourselves. Do NOT also call ANativeWindow_acquire — that would leak.
     auto *nativeWindow = ANativeWindow_fromSurface(&env, jni::Unwrap(*surface.get()));
     if (nativeWindow != aNativeWindow) {
+      if (aNativeWindow != nullptr) {
+        ANativeWindow_release(aNativeWindow);
+      }
       aNativeWindow = nativeWindow;
-      ANativeWindow_acquire(aNativeWindow);
-      renderer->setWindow(nativeWindow);
+      if (renderer) {
+        renderer->setWindow(nativeWindow);
+      }
+    } else {
+      // Same underlying window — drop the duplicate ref returned by fromSurface.
+      ANativeWindow_release(nativeWindow);
     }
-    if (nativeWindow) {
+    if (renderer) {
       renderer->updateWindowSize(width, height);
     }
   } else {
-    renderer->resetWindow();
-    ANativeWindow_release(aNativeWindow);
-    aNativeWindow = nullptr;
+    if (renderer) {
+      renderer->resetWindow();
+    }
+    if (aNativeWindow != nullptr) {
+      ANativeWindow_release(aNativeWindow);
+      aNativeWindow = nullptr;
+    }
   }
 }
 
 /** called from Android main thread on every TextureView size tick **/
 void CoreEngine::nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint height) {
-  if (aNativeWindow != nullptr) {
+  // A late callback can race with nativeDestroy() resetting the renderer — be defensive.
+  if (renderer && aNativeWindow != nullptr) {
     renderer->updateWindowSize(width, height);
   }
 }

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -43,6 +43,13 @@ void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surfa
   }
 }
 
+/** called from Android main thread on every TextureView size tick **/
+void CoreEngine::nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint height) {
+  if (aNativeWindow != nullptr) {
+    renderer->updateWindowSize(width, height);
+  }
+}
+
 /** called from worker thread **/
 void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBuffer> &buffer,
                                        jni::jint rotationDegrees, jni::jboolean backCamera) {

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -26,6 +26,7 @@ CoreEngine::~CoreEngine() = default;
 /** called from Android main thread **/
 void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surface,
                                   jni::jint width, jni::jint height) {
+  std::lock_guard<std::mutex> lock(coreEngineMutex);
   if (surface.get() != nullptr) {
     // ANativeWindow_fromSurface returns a NEW strong reference (+1 on the refcount); we own it
     // and must release it ourselves. Do NOT also call ANativeWindow_acquire — that would leak.
@@ -64,7 +65,7 @@ void CoreEngine::nativeSetSurface(JNIEnv &env, const jni::Object<Surface> &surfa
 
 /** called from Android main thread on every TextureView size tick **/
 void CoreEngine::nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint height) {
-  // A late callback can race with nativeDestroy() resetting the renderer — be defensive.
+  std::lock_guard<std::mutex> lock(coreEngineMutex);
   if (renderer && aNativeWindow != nullptr) {
     renderer->updateWindowSize(width, height);
   }
@@ -73,9 +74,7 @@ void CoreEngine::nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint 
 /** called from worker thread **/
 void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBuffer> &buffer,
                                        jni::jint rotationDegrees, jni::jboolean backCamera) {
-  // Camera worker can fire after nativeDestroy() has reset the renderer. Skip the frame rather
-  // than deref a moved-from unique_ptr — this is not race-free against a concurrent destroy
-  // (would need a mutex for that) but covers the common ordering where destroy completes first.
+  std::lock_guard<std::mutex> lock(coreEngineMutex);
   if (!renderer) {
     return;
   }
@@ -109,12 +108,14 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
 }
 
 void CoreEngine::nativeRefit(JNIEnv &env) {
+  std::lock_guard<std::mutex> lock(coreEngineMutex);
   if (renderer) {
     renderer->refit();
   }
 }
 
 void CoreEngine::nativeDestroy(JNIEnv &env) {
+  std::lock_guard<std::mutex> lock(coreEngineMutex);
   LOGI("Core engine destroy started");
   renderer.reset();
   LOGI("Core engine destroy passed");

--- a/app/src/main/native/cpp/core_engine.hpp
+++ b/app/src/main/native/cpp/core_engine.hpp
@@ -67,10 +67,7 @@ public:
   void nativeDestroy(JNIEnv &env);
 
 private:
-  // Serializes all JNI entry points against nativeDestroy. Native methods can be invoked from
-  // the Android main thread (surface / size / refit), the camera worker thread (frame upload)
-  // and the JVM finalizer thread (destroy) concurrently. Without this, reading `renderer` on
-  // one thread while `nativeDestroy` resets it on another is a C++ data race / UB.
+  // Serializes JNI entry points against nativeDestroy.
   std::mutex coreEngineMutex;
 
   ANativeWindow *aNativeWindow;

--- a/app/src/main/native/cpp/core_engine.hpp
+++ b/app/src/main/native/cpp/core_engine.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include <android/hardware_buffer.h>
 #include <android/hardware_buffer_jni.h>
 #include <android/native_window.h>
@@ -65,6 +67,12 @@ public:
   void nativeDestroy(JNIEnv &env);
 
 private:
+  // Serializes all JNI entry points against nativeDestroy. Native methods can be invoked from
+  // the Android main thread (surface / size / refit), the camera worker thread (frame upload)
+  // and the JVM finalizer thread (destroy) concurrently. Without this, reading `renderer` on
+  // one thread while `nativeDestroy` resets it on another is a C++ data race / UB.
+  std::mutex coreEngineMutex;
+
   ANativeWindow *aNativeWindow;
   std::unique_ptr <BaseRenderer> renderer;
 

--- a/app/src/main/native/cpp/core_engine.hpp
+++ b/app/src/main/native/cpp/core_engine.hpp
@@ -40,6 +40,7 @@ public:
             "initialize",
             "finalize",
             METHOD(&CoreEngine::nativeSetSurface, "nativeSetSurface"),
+            METHOD(&CoreEngine::nativeUpdateWindowSize, "nativeUpdateWindowSize"),
             METHOD(&CoreEngine::nativeSendCameraFrame, "nativeSendCameraFrame"),
             METHOD(&CoreEngine::nativeRefit, "nativeRefit"),
             METHOD(&CoreEngine::nativeDestroy, "nativeDestroy")
@@ -54,6 +55,8 @@ public:
 
   void nativeSetSurface(JNIEnv &env, jni::Object <Surface> const &surface, jni::jint width,
                         jni::jint height);
+
+  void nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint height);
 
   void nativeSendCameraFrame(JNIEnv &env, jni::Object <HardwareBuffer> const &buffer, jni::jint rotationDegrees, jni::jboolean backCamera);
 

--- a/app/src/main/native/cpp/core_engine.hpp
+++ b/app/src/main/native/cpp/core_engine.hpp
@@ -41,6 +41,7 @@ public:
             "finalize",
             METHOD(&CoreEngine::nativeSetSurface, "nativeSetSurface"),
             METHOD(&CoreEngine::nativeSendCameraFrame, "nativeSendCameraFrame"),
+            METHOD(&CoreEngine::nativeRefit, "nativeRefit"),
             METHOD(&CoreEngine::nativeDestroy, "nativeDestroy")
     );
   }
@@ -55,6 +56,8 @@ public:
                         jni::jint height);
 
   void nativeSendCameraFrame(JNIEnv &env, jni::Object <HardwareBuffer> const &buffer, jni::jint rotationDegrees, jni::jboolean backCamera);
+
+  void nativeRefit(JNIEnv &env);
 
   void nativeDestroy(JNIEnv &env);
 

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -774,10 +774,17 @@ void VulkanRenderer::renderImpl() {
   if (result == VK_ERROR_OUT_OF_DATE_KHR) {
     // The surface has changed in a way that makes the swapchain unusable. The semaphore is left
     // unsignaled in this case (per spec), so we can safely reuse it after recreating the swapchain.
-    // VK_SUBOPTIMAL_KHR is intentionally not handled here: acquisition succeeded, so we render this
-    // frame and let the next acquire trigger recreation if the surface keeps drifting.
+    // VK_SUBOPTIMAL_KHR is intentionally NOT routed here: acquisition succeeded, so we render
+    // this frame and let the next acquire trigger recreation if the surface keeps drifting.
     LOGW("vkAcquireNextImageKHR returned VK_ERROR_OUT_OF_DATE_KHR; recreating swapchain");
     recreateSwapChain(0, 0);
+    return;
+  }
+  if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
+    // Anything else (VK_ERROR_SURFACE_LOST_KHR, VK_ERROR_DEVICE_LOST, …) means nextIndex is not
+    // valid — submitting/presenting with it is UB. Skip the frame; the next render iteration
+    // will retry. CALL_VK on a fatal code is not used because we don't want to abort the looper.
+    LOGE("vkAcquireNextImageKHR returned fatal %i; dropping frame", result);
     return;
   }
   CALL_VK(vkResetFences(deviceInfo.device, 1, &renderInfo.fence))

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -1108,6 +1108,11 @@ void VulkanRenderer::createVertexBuffer() {
 
 void VulkanRenderer::cleanupSwapChain() {
   LOGI("->cleanupSwapChain");
+  // Guard against a no-op double-call: if the swapchain handle is already gone, the per-image
+  // arrays were freed in the previous call and swapchainLength may still be non-zero.
+  if (swapchainInfo.swapchain == VK_NULL_HANDLE) {
+    return;
+  }
   for (uint32_t i = 0; i < swapchainInfo.swapchainLength; ++i) {
     vkDestroyFramebuffer(deviceInfo.device, swapchainInfo.framebuffers[i], nullptr);
     vkDestroyImageView(deviceInfo.device, swapchainInfo.displayViews[i], nullptr);
@@ -1119,6 +1124,8 @@ void VulkanRenderer::cleanupSwapChain() {
   swapchainInfo.framebuffers = nullptr;
   swapchainInfo.displayViews = nullptr;
   swapchainInfo.displayImages = nullptr;
+  swapchainInfo.swapchain = VK_NULL_HANDLE;
+  swapchainInfo.swapchainLength = 0;
   LOGI("<-cleanupSwapChain");
 }
 

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -806,7 +806,14 @@ void VulkanRenderer::renderImpl() {
           .pImageIndices = &nextIndex,
           .pResults = nullptr,
   };
-  vkQueuePresentKHR(deviceInfo.queue, &presentInfo);
+  const auto presentResult = vkQueuePresentKHR(deviceInfo.queue, &presentInfo);
+  // vkQueuePresentKHR can also signal that the swapchain is out of date or suboptimal — e.g.
+  // when the surface size changes from under us. Acquire alone is not enough; we have to react
+  // here too, otherwise we'd keep presenting against a stale swapchain.
+  if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
+    LOGW("vkQueuePresentKHR returned %i; recreating swapchain", presentResult);
+    recreateSwapChain(0, 0);
+  }
 }
 
 void VulkanRenderer::createDescriptorSet() {
@@ -982,8 +989,14 @@ void VulkanRenderer::hwBufferToTexture(AHardwareBuffer *buffer) {
 }
 
 void VulkanRenderer::recordCommandBuffer() {
+  // This function may be called more than once per command buffer (e.g. from recreateSwapChain
+  // after the framebuffers have been rebuilt). The pool is created with
+  // VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT (see createOtherStaff), so the call to
+  // vkBeginCommandBuffer below implicitly resets each buffer from Executable -> Initial — no
+  // explicit vkResetCommandBuffer is required. Callers must ensure the buffers are not in the
+  // Pending state (already in flight on the GPU); recreateSwapChain handles that with
+  // vkQueueWaitIdle before getting here.
   for (int bufferIndex = 0; bufferIndex < swapchainInfo.swapchainLength; bufferIndex++) {
-    // We start by creating and declare the "beginning" our command buffer
     VkCommandBufferBeginInfo cmdBufferBeginInfo{
             .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
             .pNext = nullptr,

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -143,9 +143,6 @@ void VulkanRenderer::createVulkanDevice(VkApplicationInfo *appInfo) {
 
   CALL_VK(vkCreateDevice(deviceInfo.gpuDevice, &deviceCreateInfo, nullptr,
                          &deviceInfo.device))
-  // Use the queue family index we actually discovered above — hardcoding 0 here would return an
-  // invalid queue on devices where the graphics family isn't at index 0, and would also misalign
-  // vkQueueWaitIdle in recreateSwapChain (which assumes deviceInfo.queue belongs to this family).
   vkGetDeviceQueue(deviceInfo.device, deviceInfo.queueFamilyIndex, 0, &deviceInfo.queue);
 }
 
@@ -207,8 +204,6 @@ void VulkanRenderer::createSwapChain(uint32_t width, uint32_t height,
           .presentMode = VK_PRESENT_MODE_FIFO_KHR,
           // changed to true based on https://vulkan-tutorial.com/Drawing_a_triangle/Presentation/Swap_chain
           .clipped = VK_TRUE,
-          // Hand off to the driver so it can reuse internal allocations from the previous chain.
-          // Without this, every resize tick triggers a full driver-side reallocation.
           .oldSwapchain = oldSwapchain,
   };
   CALL_VK(vkCreateSwapchainKHR(deviceInfo.device, &swapchainCreateInfo, nullptr,
@@ -723,9 +718,7 @@ void VulkanRenderer::createOtherStaff() {
   CALL_VK(vkCreateSampler(deviceInfo.device, &sampler, nullptr,
                           &externalTextureInfo.sampler))
 
-  // Create a pool of command buffers to allocate command buffer from. Match the queue family we
-  // actually discovered in createVulkanDevice — the command buffers allocated here will be
-  // submitted to deviceInfo.queue, which belongs to deviceInfo.queueFamilyIndex.
+  // Create a pool of command buffers to allocate command buffer from
   VkCommandPoolCreateInfo cmdPoolCreateInfo{
           .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
           .pNext = nullptr,
@@ -777,18 +770,12 @@ void VulkanRenderer::renderImpl() {
                                       UINT64_MAX, renderInfo.semaphore, VK_NULL_HANDLE,
                                       &nextIndex);
   if (result == VK_ERROR_OUT_OF_DATE_KHR) {
-    // The surface has changed in a way that makes the swapchain unusable. The semaphore is left
-    // unsignaled in this case (per spec), so we can safely reuse it after recreating the swapchain.
-    // VK_SUBOPTIMAL_KHR is intentionally NOT routed here: acquisition succeeded, so we render
-    // this frame and let the next acquire trigger recreation if the surface keeps drifting.
     LOGW("vkAcquireNextImageKHR returned VK_ERROR_OUT_OF_DATE_KHR; recreating swapchain");
     recreateSwapChain(0, 0);
     return;
   }
   if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
-    // Anything else (VK_ERROR_SURFACE_LOST_KHR, VK_ERROR_DEVICE_LOST, …) means nextIndex is not
-    // valid — submitting/presenting with it is UB. Skip the frame; the next render iteration
-    // will retry. CALL_VK on a fatal code is not used because we don't want to abort the looper.
+    // nextIndex is undefined for non-success codes — dropping the frame.
     LOGE("vkAcquireNextImageKHR returned fatal %i; dropping frame", result);
     return;
   }
@@ -819,11 +806,6 @@ void VulkanRenderer::renderImpl() {
           .pResults = nullptr,
   };
   const auto presentResult = vkQueuePresentKHR(deviceInfo.queue, &presentInfo);
-  // vkQueuePresentKHR can also signal that the swapchain is out of date or suboptimal — e.g.
-  // when the surface size changes from under us. Acquire alone is not enough; we have to react
-  // here too, otherwise we'd keep presenting against a stale swapchain. Any other non-SUCCESS
-  // return (e.g. VK_ERROR_SURFACE_LOST_KHR, VK_ERROR_DEVICE_LOST) is fatal for this surface —
-  // log it loudly so it's visible in logcat rather than silently dropping the failure.
   if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
     LOGW("vkQueuePresentKHR returned %i; recreating swapchain", presentResult);
     recreateSwapChain(0, 0);
@@ -1005,13 +987,9 @@ void VulkanRenderer::hwBufferToTexture(AHardwareBuffer *buffer) {
 }
 
 void VulkanRenderer::recordCommandBuffer() {
-  // This function may be called more than once per command buffer (e.g. from recreateSwapChain
-  // after the framebuffers have been rebuilt). The pool is created with
-  // VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT (see createOtherStaff), so the call to
-  // vkBeginCommandBuffer below implicitly resets each buffer from Executable -> Initial — no
-  // explicit vkResetCommandBuffer is required. Callers must ensure the buffers are not in the
-  // Pending state (already in flight on the GPU); recreateSwapChain handles that with
-  // vkQueueWaitIdle before getting here.
+  // vkBeginCommandBuffer implicitly resets (pool flag VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+  // callers must ensure the buffers aren't in the Pending state — recreateSwapChain
+  // guarantees that via vkQueueWaitIdle.
   for (int bufferIndex = 0; bufferIndex < swapchainInfo.swapchainLength; bufferIndex++) {
     VkCommandBufferBeginInfo cmdBufferBeginInfo{
             .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
@@ -1113,8 +1091,6 @@ void VulkanRenderer::createVertexBuffer() {
 
 void VulkanRenderer::cleanupSwapChain() {
   LOGI("->cleanupSwapChain");
-  // Guard against a no-op double-call: if the swapchain handle is already gone, the per-image
-  // arrays were freed in the previous call and swapchainLength may still be non-zero.
   if (swapchainInfo.swapchain == VK_NULL_HANDLE) {
     return;
   }
@@ -1136,13 +1112,9 @@ void VulkanRenderer::cleanupSwapChain() {
 
 void VulkanRenderer::recreateSwapChain(uint32_t width, uint32_t height) {
   LOGI("->recreateSwapChain");
-  // We only ever submit and present on this single queue, so waiting on it is sufficient — much
-  // cheaper than vkDeviceWaitIdle, which serializes every queue on the device.
   CALL_VK(vkQueueWaitIdle(deviceInfo.queue))
 
-  // Tear down resources that reference the old swapchain images (framebuffers + image views), but
-  // keep the old swapchain handle alive so we can pass it as oldSwapchain to the new one — this
-  // lets the driver retire it gracefully instead of reallocating from scratch.
+  // Keep the old swapchain handle alive so we can hand it to vkCreateSwapchainKHR's oldSwapchain.
   VkSwapchainKHR retiredSwapchain = swapchainInfo.swapchain;
   for (uint32_t i = 0; i < swapchainInfo.swapchainLength; ++i) {
     vkDestroyFramebuffer(deviceInfo.device, swapchainInfo.framebuffers[i], nullptr);
@@ -1158,8 +1130,6 @@ void VulkanRenderer::recreateSwapChain(uint32_t width, uint32_t height) {
   createSwapChain(width, height, retiredSwapchain);
   vkDestroySwapchainKHR(deviceInfo.device, retiredSwapchain, nullptr);
   createFrameBuffersAndImages();
-  // The new swapchain may have a different image count than the old one — reallocate the command
-  // buffer storage so we have exactly one primary command buffer per framebuffer.
   if (renderInfo.cmdBufferLen != swapchainInfo.swapchainLength) {
     vkFreeCommandBuffers(deviceInfo.device, renderInfo.cmdPool,
                          renderInfo.cmdBufferLen, renderInfo.cmdBuffer);
@@ -1176,8 +1146,6 @@ void VulkanRenderer::recreateSwapChain(uint32_t width, uint32_t height) {
     CALL_VK(vkAllocateCommandBuffers(deviceInfo.device, &cmdBufferCreateInfo,
                                      renderInfo.cmdBuffer))
   }
-  // Re-record so render() does not submit a command buffer that references destroyed framebuffers.
-  // Skipped when there is no camera frame yet — the first hwBufferToTexture() will record then.
   if (cameraInitialized) {
     recordCommandBuffer();
   }

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -143,7 +143,10 @@ void VulkanRenderer::createVulkanDevice(VkApplicationInfo *appInfo) {
 
   CALL_VK(vkCreateDevice(deviceInfo.gpuDevice, &deviceCreateInfo, nullptr,
                          &deviceInfo.device))
-  vkGetDeviceQueue(deviceInfo.device, 0, 0, &deviceInfo.queue);
+  // Use the queue family index we actually discovered above — hardcoding 0 here would return an
+  // invalid queue on devices where the graphics family isn't at index 0, and would also misalign
+  // vkQueueWaitIdle in recreateSwapChain (which assumes deviceInfo.queue belongs to this family).
+  vkGetDeviceQueue(deviceInfo.device, deviceInfo.queueFamilyIndex, 0, &deviceInfo.queue);
 }
 
 void VulkanRenderer::createSwapChain(uint32_t width, uint32_t height,
@@ -720,12 +723,14 @@ void VulkanRenderer::createOtherStaff() {
   CALL_VK(vkCreateSampler(deviceInfo.device, &sampler, nullptr,
                           &externalTextureInfo.sampler))
 
-  // Create a pool of command buffers to allocate command buffer from
+  // Create a pool of command buffers to allocate command buffer from. Match the queue family we
+  // actually discovered in createVulkanDevice — the command buffers allocated here will be
+  // submitted to deviceInfo.queue, which belongs to deviceInfo.queueFamilyIndex.
   VkCommandPoolCreateInfo cmdPoolCreateInfo{
           .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
           .pNext = nullptr,
           .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
-          .queueFamilyIndex = 0,
+          .queueFamilyIndex = deviceInfo.queueFamilyIndex,
   };
   CALL_VK(vkCreateCommandPool(deviceInfo.device, &cmdPoolCreateInfo, nullptr,
                               &renderInfo.cmdPool))

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -816,10 +816,14 @@ void VulkanRenderer::renderImpl() {
   const auto presentResult = vkQueuePresentKHR(deviceInfo.queue, &presentInfo);
   // vkQueuePresentKHR can also signal that the swapchain is out of date or suboptimal — e.g.
   // when the surface size changes from under us. Acquire alone is not enough; we have to react
-  // here too, otherwise we'd keep presenting against a stale swapchain.
+  // here too, otherwise we'd keep presenting against a stale swapchain. Any other non-SUCCESS
+  // return (e.g. VK_ERROR_SURFACE_LOST_KHR, VK_ERROR_DEVICE_LOST) is fatal for this surface —
+  // log it loudly so it's visible in logcat rather than silently dropping the failure.
   if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
     LOGW("vkQueuePresentKHR returned %i; recreating swapchain", presentResult);
     recreateSwapChain(0, 0);
+  } else if (presentResult != VK_SUCCESS) {
+    LOGE("vkQueuePresentKHR returned fatal %i", presentResult);
   }
 }
 

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -146,7 +146,8 @@ void VulkanRenderer::createVulkanDevice(VkApplicationInfo *appInfo) {
   vkGetDeviceQueue(deviceInfo.device, 0, 0, &deviceInfo.queue);
 }
 
-void VulkanRenderer::createSwapChain(uint32_t width, uint32_t height) {
+void VulkanRenderer::createSwapChain(uint32_t width, uint32_t height,
+                                     VkSwapchainKHR oldSwapchain) {
   LOGI("->createSwapChain");
   // **********************************************************
   // Get the surface capabilities because:
@@ -203,7 +204,9 @@ void VulkanRenderer::createSwapChain(uint32_t width, uint32_t height) {
           .presentMode = VK_PRESENT_MODE_FIFO_KHR,
           // changed to true based on https://vulkan-tutorial.com/Drawing_a_triangle/Presentation/Swap_chain
           .clipped = VK_TRUE,
-          .oldSwapchain = VK_NULL_HANDLE,
+          // Hand off to the driver so it can reuse internal allocations from the previous chain.
+          // Without this, every resize tick triggers a full driver-side reallocation.
+          .oldSwapchain = oldSwapchain,
   };
   CALL_VK(vkCreateSwapchainKHR(deviceInfo.device, &swapchainCreateInfo, nullptr,
                                &swapchainInfo.swapchain))
@@ -768,11 +771,13 @@ void VulkanRenderer::renderImpl() {
   auto result = vkAcquireNextImageKHR(deviceInfo.device, swapchainInfo.swapchain,
                                       UINT64_MAX, renderInfo.semaphore, VK_NULL_HANDLE,
                                       &nextIndex);
-  if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
-    LOGW("vkAcquireNextImageKHR returned %i; swapchain will be recreated", result);
-    cleanupSwapChain();
-    createSwapChain();
-    createFrameBuffersAndImages();
+  if (result == VK_ERROR_OUT_OF_DATE_KHR) {
+    // The surface has changed in a way that makes the swapchain unusable. The semaphore is left
+    // unsignaled in this case (per spec), so we can safely reuse it after recreating the swapchain.
+    // VK_SUBOPTIMAL_KHR is intentionally not handled here: acquisition succeeded, so we render this
+    // frame and let the next acquire trigger recreation if the surface keeps drifting.
+    LOGW("vkAcquireNextImageKHR returned VK_ERROR_OUT_OF_DATE_KHR; recreating swapchain");
+    recreateSwapChain(0, 0);
     return;
   }
   CALL_VK(vkResetFences(deviceInfo.device, 1, &renderInfo.fence))
@@ -1077,14 +1082,70 @@ void VulkanRenderer::createVertexBuffer() {
   vkUnmapMemory(deviceInfo.device, buffersInfo.vertexBufferMemory);
 }
 
-void VulkanRenderer::cleanupSwapChain() const {
+void VulkanRenderer::cleanupSwapChain() {
   LOGI("->cleanupSwapChain");
-  for (int i = 0; i < swapchainInfo.swapchainLength; ++i) {
+  for (uint32_t i = 0; i < swapchainInfo.swapchainLength; ++i) {
     vkDestroyFramebuffer(deviceInfo.device, swapchainInfo.framebuffers[i], nullptr);
     vkDestroyImageView(deviceInfo.device, swapchainInfo.displayViews[i], nullptr);
   }
   vkDestroySwapchainKHR(deviceInfo.device, swapchainInfo.swapchain, nullptr);
+  delete[] swapchainInfo.framebuffers;
+  delete[] swapchainInfo.displayViews;
+  delete[] swapchainInfo.displayImages;
+  swapchainInfo.framebuffers = nullptr;
+  swapchainInfo.displayViews = nullptr;
+  swapchainInfo.displayImages = nullptr;
   LOGI("<-cleanupSwapChain");
+}
+
+void VulkanRenderer::recreateSwapChain(uint32_t width, uint32_t height) {
+  LOGI("->recreateSwapChain");
+  // We only ever submit and present on this single queue, so waiting on it is sufficient — much
+  // cheaper than vkDeviceWaitIdle, which serializes every queue on the device.
+  CALL_VK(vkQueueWaitIdle(deviceInfo.queue))
+
+  // Tear down resources that reference the old swapchain images (framebuffers + image views), but
+  // keep the old swapchain handle alive so we can pass it as oldSwapchain to the new one — this
+  // lets the driver retire it gracefully instead of reallocating from scratch.
+  VkSwapchainKHR retiredSwapchain = swapchainInfo.swapchain;
+  for (uint32_t i = 0; i < swapchainInfo.swapchainLength; ++i) {
+    vkDestroyFramebuffer(deviceInfo.device, swapchainInfo.framebuffers[i], nullptr);
+    vkDestroyImageView(deviceInfo.device, swapchainInfo.displayViews[i], nullptr);
+  }
+  delete[] swapchainInfo.framebuffers;
+  delete[] swapchainInfo.displayViews;
+  delete[] swapchainInfo.displayImages;
+  swapchainInfo.framebuffers = nullptr;
+  swapchainInfo.displayViews = nullptr;
+  swapchainInfo.displayImages = nullptr;
+
+  createSwapChain(width, height, retiredSwapchain);
+  vkDestroySwapchainKHR(deviceInfo.device, retiredSwapchain, nullptr);
+  createFrameBuffersAndImages();
+  // The new swapchain may have a different image count than the old one — reallocate the command
+  // buffer storage so we have exactly one primary command buffer per framebuffer.
+  if (renderInfo.cmdBufferLen != swapchainInfo.swapchainLength) {
+    vkFreeCommandBuffers(deviceInfo.device, renderInfo.cmdPool,
+                         renderInfo.cmdBufferLen, renderInfo.cmdBuffer);
+    delete[] renderInfo.cmdBuffer;
+    renderInfo.cmdBufferLen = swapchainInfo.swapchainLength;
+    renderInfo.cmdBuffer = new VkCommandBuffer[swapchainInfo.swapchainLength];
+    VkCommandBufferAllocateInfo cmdBufferCreateInfo{
+            .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+            .pNext = nullptr,
+            .commandPool = renderInfo.cmdPool,
+            .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+            .commandBufferCount = renderInfo.cmdBufferLen,
+    };
+    CALL_VK(vkAllocateCommandBuffers(deviceInfo.device, &cmdBufferCreateInfo,
+                                     renderInfo.cmdBuffer))
+  }
+  // Re-record so render() does not submit a command buffer that references destroyed framebuffers.
+  // Skipped when there is no camera frame yet — the first hwBufferToTexture() will record then.
+  if (cameraInitialized) {
+    recordCommandBuffer();
+  }
+  LOGI("<-recreateSwapChain");
 }
 
 void VulkanRenderer::cleanup() {
@@ -1101,6 +1162,7 @@ void VulkanRenderer::cleanup() {
   vkDestroySemaphore(deviceInfo.device, renderInfo.semaphore, nullptr);
   vkDestroyFence(deviceInfo.device, renderInfo.fence, nullptr);
   vkDestroyCommandPool(deviceInfo.device, renderInfo.cmdPool, nullptr);
+  delete[] renderInfo.cmdBuffer;
   vkDestroySampler(deviceInfo.device, externalTextureInfo.sampler, nullptr);
   if (cameraInitialized) {
     vkDestroyImage(deviceInfo.device, externalTextureInfo.image, nullptr);

--- a/app/src/main/native/cpp/vulkan_renderer.hpp
+++ b/app/src/main/native/cpp/vulkan_renderer.hpp
@@ -212,8 +212,10 @@ private:
   void recordCommandBuffer();
 
   /**
-   * Wait for device idle, tear down the swapchain-dependent objects, recreate them for the new
-   * surface size, and re-record command buffers so they no longer reference destroyed framebuffers.
+   * Drain the graphics/present queue, tear down the swapchain-dependent objects, recreate them
+   * for the new surface size, and re-record command buffers so they no longer reference
+   * destroyed framebuffers. Uses vkQueueWaitIdle on the single queue we submit to (cheaper than
+   * vkDeviceWaitIdle, sufficient because all swapchain-related work goes through that queue).
    * Pass (0, 0) to use the current surface extent (recovery path from VK_ERROR_OUT_OF_DATE_KHR).
    */
   void recreateSwapChain(uint32_t width, uint32_t height);

--- a/app/src/main/native/cpp/vulkan_renderer.hpp
+++ b/app/src/main/native/cpp/vulkan_renderer.hpp
@@ -47,13 +47,19 @@ protected:
   }
 
   void onWindowSizeUpdated(int width, int height) override {
+    // Intentionally a no-op for Vulkan. Per-tick layout changes during an animation only update
+    // the MVP via BaseRenderer; the swapchain re-fit is deferred to UI-driven key frames in
+    // onRefit() so we don't pay a full rebuild for every frame of an animation.
+  }
+
+  void onRefit(int width, int height) override {
+    // Vulkan globals only exist between onWindowCreated and onWindowDestroyed; refit() can be
+    // invoked outside that window so guard before dereferencing any Vulkan handle.
+    if (!deviceInfo.initialized) {
+      return;
+    }
     if (width != swapchainInfo.displaySize.width || height != swapchainInfo.displaySize.height) {
-      LOGI("->onWindowSizeUpdated");
-      CALL_VK(vkDeviceWaitIdle(deviceInfo.device))
-      cleanupSwapChain();
-      createSwapChain(width, height);
-      createFrameBuffersAndImages();
-      LOGI("<-onWindowSizeUpdated");
+      recreateSwapChain(static_cast<uint32_t>(width), static_cast<uint32_t>(height));
     }
   }
 
@@ -186,7 +192,8 @@ private:
 
   void createVulkanDevice(VkApplicationInfo* appInfo);
 
-  void createSwapChain(uint32_t width = 0, uint32_t height = 0);
+  void createSwapChain(uint32_t width = 0, uint32_t height = 0,
+                       VkSwapchainKHR oldSwapchain = VK_NULL_HANDLE);
 
   void createRenderPass();
 
@@ -204,9 +211,16 @@ private:
 
   void recordCommandBuffer();
 
+  /**
+   * Wait for device idle, tear down the swapchain-dependent objects, recreate them for the new
+   * surface size, and re-record command buffers so they no longer reference destroyed framebuffers.
+   * Pass (0, 0) to use the current surface extent (recovery path from VK_ERROR_OUT_OF_DATE_KHR).
+   */
+  void recreateSwapChain(uint32_t width, uint32_t height);
+
   ////// Destroy functions
 
-  void cleanupSwapChain() const;
+  void cleanupSwapChain();
 
   void cleanup();
 

--- a/app/src/main/native/cpp/vulkan_renderer.hpp
+++ b/app/src/main/native/cpp/vulkan_renderer.hpp
@@ -46,15 +46,10 @@ protected:
     return true;
   }
 
-  void onWindowSizeUpdated(int width, int height) override {
-    // Intentionally a no-op for Vulkan. Per-tick layout changes during an animation only update
-    // the MVP via BaseRenderer; the swapchain re-fit is deferred to UI-driven key frames in
-    // onRefit() so we don't pay a full rebuild for every frame of an animation.
-  }
+  // Per-tick hook is a no-op for Vulkan; the swapchain re-fit happens in onRefit instead.
+  void onWindowSizeUpdated(int width, int height) override {}
 
   void onRefit(int width, int height) override {
-    // Vulkan globals only exist between onWindowCreated and onWindowDestroyed; refit() can be
-    // invoked outside that window so guard before dereferencing any Vulkan handle.
     if (!deviceInfo.initialized) {
       return;
     }
@@ -64,9 +59,6 @@ protected:
   }
 
   void onWindowDestroyed() override {
-    // If onWindowCreated failed (e.g. InitVulkan returned false) we can still be invoked by
-    // BaseRenderer::resetWindow during teardown. In that case deviceInfo.device is VK_NULL_HANDLE
-    // (value-initialized) and vkDeviceWaitIdle on it would crash — bail out cleanly.
     if (!deviceInfo.initialized) {
       return;
     }
@@ -217,13 +209,8 @@ private:
 
   void recordCommandBuffer();
 
-  /**
-   * Drain the graphics/present queue, tear down the swapchain-dependent objects, recreate them
-   * for the new surface size, and re-record command buffers so they no longer reference
-   * destroyed framebuffers. Uses vkQueueWaitIdle on the single queue we submit to (cheaper than
-   * vkDeviceWaitIdle, sufficient because all swapchain-related work goes through that queue).
-   * Pass (0, 0) to use the current surface extent (recovery path from VK_ERROR_OUT_OF_DATE_KHR).
-   */
+  // Tear down + recreate the swapchain at (width, height) and re-record command buffers.
+  // Pass (0, 0) to use the current surface extent.
   void recreateSwapChain(uint32_t width, uint32_t height);
 
   ////// Destroy functions

--- a/app/src/main/native/cpp/vulkan_renderer.hpp
+++ b/app/src/main/native/cpp/vulkan_renderer.hpp
@@ -64,6 +64,12 @@ protected:
   }
 
   void onWindowDestroyed() override {
+    // If onWindowCreated failed (e.g. InitVulkan returned false) we can still be invoked by
+    // BaseRenderer::resetWindow during teardown. In that case deviceInfo.device is VK_NULL_HANDLE
+    // (value-initialized) and vkDeviceWaitIdle on it would crash — bail out cleanly.
+    if (!deviceInfo.initialized) {
+      return;
+    }
     CALL_VK(vkDeviceWaitIdle(deviceInfo.device))
     cleanup();
     deviceInfo.initialized = false;

--- a/app/src/main/native/cpp/vulkan_renderer.hpp
+++ b/app/src/main/native/cpp/vulkan_renderer.hpp
@@ -116,7 +116,7 @@ private:
 
   ///////// Structs and variables
 
-  bool cameraInitialized;
+  bool cameraInitialized = false;
 
   struct UniformBufferObject {
     glm::mat4 mvp;
@@ -134,7 +134,7 @@ private:
     VkSurfaceKHR surface;
     VkQueue queue;
   };
-  VulkanDeviceInfo deviceInfo;
+  VulkanDeviceInfo deviceInfo{};
 
   struct VulkanSwapchainInfo {
     VkSwapchainKHR swapchain;
@@ -148,7 +148,7 @@ private:
     VkImage* displayImages;
     VkImageView* displayViews;
   };
-  VulkanSwapchainInfo swapchainInfo;
+  VulkanSwapchainInfo swapchainInfo{};
 
   struct VulkanExternalTextureInfo {
     VkSampler sampler;
@@ -156,7 +156,7 @@ private:
     VkDeviceMemory memory;
     VkImageView view;
   };
-  VulkanExternalTextureInfo externalTextureInfo;
+  VulkanExternalTextureInfo externalTextureInfo{};
 
   struct VulkanBuffersInfo {
     VkBuffer vertexBuf;
@@ -165,7 +165,7 @@ private:
     VkDeviceMemory vertexBufferMemory;
     void* uniformBufferMapped;
   };
-  VulkanBuffersInfo buffersInfo;
+  VulkanBuffersInfo buffersInfo{};
 
   struct VulkanGfxPipelineInfo {
     VkDescriptorSetLayout dscLayout;
@@ -176,7 +176,7 @@ private:
     VkPipeline pipeline;
     VkWriteDescriptorSet* descWrites;
   };
-  VulkanGfxPipelineInfo gfxPipelineInfo;
+  VulkanGfxPipelineInfo gfxPipelineInfo{};
 
   struct VulkanRenderInfo {
     VkRenderPass renderPass;
@@ -186,7 +186,7 @@ private:
     VkSemaphore semaphore;
     VkFence fence;
   };
-  VulkanRenderInfo renderInfo;
+  VulkanRenderInfo renderInfo{};
 
   ///////// Create functions
 


### PR DESCRIPTION
### Summary

Migrate camera previews from `SurfaceView` to `TextureView` and make the dual-preview resize animation smooth on both OpenGL and Vulkan. Also fixes a handful of latent bugs in the Vulkan swapchain teardown / recreate path, the JNI lifecycle, and concurrent access to renderer state.

### Features

- **`SurfaceView` → `TextureView`** so the preview is composited in the view hierarchy and animates in lockstep with the surrounding layout.
- **Shrink-to-zero resize animation** (1s tween, was 0 ms). `Modifier.weight` is coerced to a sub-pixel floor so the visible Box rounds to 0 px before `finishedListener` removes it — no more "10 % sliver → gone" pop.
- **`CoreEngine.refit(weight)` API** driven from a Compose `SideEffect`. Filters by threshold crossings (`0.1`, `0.5`) + endpoint settlement (`0.0`/`1.0`) on the Kotlin side, so the JNI layer only sees frames worth reacting to.
- **`BaseRenderer.refit()` → `onRefit(w, h)`** virtual: Vulkan rebuilds its swapchain there; OpenGL keeps its per-tick `glViewport` in `onWindowSizeUpdated`.
- **Vulkan swapchain recreate** rewritten: passes `oldSwapchain` to `vkCreateSwapchainKHR` (driver can reuse allocations), waits on `vkQueueWaitIdle` instead of device-wide idle, re-records command buffers, reallocates `cmdBuffer[]` if the image count changes.
- **`updateWindowSize` coalescing** under `resizeMutex` — bursts of `surfaceTextureSizeChanged` collapse into a single render-thread task reading the latest dimensions; rescheduled if newer pending values arrive mid-task.

### Bug fixes

- **`ANativeWindow` refcount** in `nativeSetSurface`: was leaking one ref per resize tick (`fromSurface` returns +1 and we additionally called `_acquire`; same-window branch never released the temporary). Plus a dedicated `nativeUpdateWindowSize` so size-only ticks don't go through `fromSurface` at all.
- **`nativeDestroy` cleanup**: now releases `aNativeWindow` and `gpuBuffer` instead of leaving them dangling.
- **JNI entry-point synchronization**: `std::mutex coreEngineMutex` guards `renderer` against concurrent `nativeDestroy` from any thread. CPU-fallback frame copy drops the mutex around the slow `memcpy` so main-thread JNI calls aren't blocked behind it; `gpuBuffer` retained with a `+1` ref during that window.
- **Vulkan return-code handling**: `vkAcquireNextImageKHR` and `vkQueuePresentKHR` now treat `SURFACE_LOST` / `DEVICE_LOST` / etc. as fatal (log + drop frame) instead of silently continuing; `OUT_OF_DATE` / `SUBOPTIMAL` route through `recreateSwapChain`.
- **`cleanupSwapChain` idempotent**: resets `swapchain` handle + `swapchainLength` and early-returns on a double call.
- **Vulkan POD members zero-initialized** (`deviceInfo{}`, `cameraInitialized = false`, etc.) — previously the guards read indeterminate values.
- **`queueFamilyIndex`** used consistently (`vkGetDeviceQueue`, command pool) — was hardcoded `0`, would have broken on devices where graphics isn't queue family 0.
- **`onWindowDestroyed`** guarded on `deviceInfo.initialized` — wouldn't crash if `InitVulkan` had failed.
- **`TextureView` setter** handles the case where the view is already available (manual `onSurfaceTextureAvailable` invocation); destroy callback clears the strong reference so the View / Context can be GC'd.
- **`onSurfaceTextureAvailable`** releases any stale `Surface` before overwriting.
- **`updateMvp`** guards against 0-dim viewport (TextureView fires `(W, 0)` during weight=0 animation frames → would produce inf/NaN matrices).
- **`shouldRefit` endpoint detection** uses transition-into-rest (`curr <= 0f && prev > 0f`) instead of exact float equality — robust to non-tween animation specs.
- **`nativeSetSurface`** bails on `ANativeWindow_fromSurface` returning null.
- **`Camera2`**: null-safe `acquireLatestImage()` / `close()`.

### Test plan

- [ ] Both previews visible → click either: shrinks smoothly to gone, no flicker, no corruption.
- [ ] "Back to both" from single-view: preview grows back smoothly; Vulkan sharpens up at the refit checkpoints.
- [ ] Backgrounding + foregrounding doesn't crash and previews come back at full resolution.
- [ ] Rotation cycles cleanly without leaks.
