### PR TITLE
Instrument per-frame timing via ATrace async sections

### DIFF
--- a/.claude/skills/frame-latency-baseline/SKILL.md
+++ b/.claude/skills/frame-latency-baseline/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: frame-latency-baseline
+description: Establish a frame-latency baseline by running 5 × 10s Perfetto captures of CameraActivity on the attached device, force-stopping the app between runs, and printing run-to-run dispersion (mean / stdev / CV%) for every dz.frame_* slice. Use to validate that an instrumentation- or rendering-path change hasn't regressed, or to refresh the baseline numbers on a new device.
+---
+
+# frame-latency-baseline
+
+Runs the one-shot frame-latency measurement five times and aggregates dispersion across the runs, so that a single regression-vs-noise judgement can be made from the same command.
+
+## Preconditions
+
+- A device is connected via `adb` (exactly one device in `device` state; export `ANDROID_SERIAL=<serial>` if multiple).
+- The debug APK is installed:
+  ```bash
+  ./gradlew :app:installDebug -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')
+  ```
+- `python3` and `curl` are on `PATH`. The first run downloads Perfetto's `trace_processor` into `.cache/frame-latency/` (gitignored, ~25 MB).
+
+## Run it
+
+```bash
+scripts/baseline-frame-latency.sh             # 5 runs × 10 s   (defaults)
+scripts/baseline-frame-latency.sh 3 5          # 3 runs × 5 s   (faster smoke test)
+```
+
+The script:
+
+1. Loops the chosen number of times. Each iteration:
+   - Calls `scripts/measure-frame-latency.sh <seconds>`, which `force-stop`s the app, grants `CAMERA`, launches `CameraActivity`, captures a Perfetto trace with `-a com.dz.camerafast`, and prints the per-run table.
+   - `adb shell am force-stop com.dz.camerafast` after the capture so the next iteration starts from a cold launch.
+   - Sleeps 2 s between iterations.
+2. Parses each per-run table, aggregates `n / avg / p50 / p90 / p99 / max` across the runs, and prints the dispersion table.
+3. Writes `.cache/frame-latency/baseline.txt` (the table) and `.cache/frame-latency/baseline.json` (machine-readable, one entry per stage × metric with `mean / stdev / cv_pct / values`).
+
+The JSON is the form CI will diff against in a future commit (PR-vs-main regression gate). Treat it as the artifact, the txt as a human view.
+
+## How to read the dispersion table
+
+For each stage × metric you get `mean`, `stdev`, `range`, `CV% = stdev / mean * 100`, plus the raw 5 values.
+
+CV% is the call to make:
+- **< 5%** — stable enough to gate PRs on (~5% tolerance).
+- **5–10%** — usable with a wider gate or as a secondary signal.
+- **> 10%** — too noisy to gate; track trend only.
+
+Findings from the SM-F936B / Android 16 baseline (see CLAUDE.md for the latest numbers):
+- `frame_e2e.{gl,vk}.avg`, `frame_e2e.{gl,vk}.p90`, `frame_to_screen.{gl,vk}.p90` are consistently sub-2% CV at 10 s — these are the headline gating metrics.
+- `frame_native_proc.{gl,vk}` p90/p99 fluctuate 6–16% — informational only.
+- All `max` columns and `p50` on screen-facing stages are bimodal / outlier-driven — don't gate.
+
+## When to re-establish the baseline
+
+- New device or new Android version.
+- Renderer-impacting code change merged to `main` (and you want the post-merge numbers as the new floor).
+- Capture-tooling change (Perfetto version, atrace categories, capture duration).
+
+Bumping the baseline because "the numbers got worse and CI was failing" is the wrong move — the point of the baseline is to fail in that case. Investigate first.
+
+## Gotchas
+
+- **`-a com.dz.camerafast` is mandatory** in the perfetto invocation. Without it, app-tag atrace sections (which is where `Trace.beginAsyncSection` and `ATrace_beginAsyncSection` slices land) are filtered out and the trace processor will return zero `dz.frame_*` rows. The wrapper script always sets it; if you ever invoke `perfetto` by hand, don't forget.
+- **Foldables / multi-display devices** still need an explicit display id only if you screenshot — `screencap` corrupts its PNG output without `-d <id>`. Trace capture is unaffected.
+- **N is intentionally hard-coded to 5 runs by default.** Three runs is enough to spot mean drift but not to estimate stdev reliably; five is the cheapest count that gives a meaningful CV. Above 10, you're spending capture minutes for diminishing accuracy.
+
+## Failure modes the script reports
+
+- `error: no adb device in 'device' state.` — plug the device in, accept the ADB prompt.
+- `error: multiple adb devices attached` — set `ANDROID_SERIAL=<serial>`.
+- `error: com.dz.camerafast is not installed` — run the `installDebug` command from "Preconditions".
+- `error: no dz.frame_* slices captured.` — usually means the APK is older than the instrumentation commit; rebuild and reinstall.

--- a/.claude/skills/frame-latency-baseline/SKILL.md
+++ b/.claude/skills/frame-latency-baseline/SKILL.md
@@ -10,9 +10,9 @@ Runs the one-shot frame-latency measurement five times and aggregates dispersion
 ## Preconditions
 
 - A device is connected via `adb` (exactly one device in `device` state; export `ANDROID_SERIAL=<serial>` if multiple).
-- The debug APK is installed:
+- The **release** APK is installed — debug NDK builds add noticeable overhead and would invalidate the baseline. Release is signed with the debug keystore and declares `<profileable android:shell="true"/>`, so:
   ```bash
-  ./gradlew :app:installDebug -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')
+  ./gradlew :app:installRelease -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')
   ```
 - `python3` and `curl` are on `PATH`. The first run downloads Perfetto's `trace_processor` into `.cache/frame-latency/` (gitignored, ~25 MB).
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .cxx
 **/build
 /.idea
+/.cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Key files:
 - `app/src/main/java/com/dz/camerafast/CameraX.kt`, `Camera2.kt` — analyzer entry points.
 - `app/src/main/java/com/dz/camerafast/CoreEngine.kt` — Kotlin-side JNI surface + `TextureView.SurfaceTextureListener`.
 - `app/src/main/native/cpp/core_engine.{hpp,cpp}` — JNI peer; holds the renderer and the `ANativeWindow`.
-- `app/src/main/native/cpp/base_renderer.{hpp,cpp}` — render-thread Looper, frame-task scheduling, viewport/MVP coalescing, the `pendingPresentCookie` interlock.
+- `app/src/main/native/cpp/base_renderer.{hpp,cpp}` — render-thread Looper, frame-task scheduling, viewport/MVP coalescing, the `pendingPresentFrameId` interlock.
 - `app/src/main/native/cpp/{opengl,vulkan}_renderer.{hpp,cpp}` — backend-specific code; the only place EGL/GL or Vulkan symbols are touched.
 
 The CPU fallback in `nativeSendCameraFrame` exists because **CameraX**'s `ImageAnalysis` delivers HW buffers with `USAGE_CPU_*` flags rather than `USAGE_GPU_SAMPLED_IMAGE`. We re-allocate a GPU buffer once, `memcpy` into it each frame (drops the engine mutex during the slow memcpy so main-thread JNI calls aren't blocked), then hand it to the renderer. Camera2 with `ImageFormat.PRIVATE` + `USAGE_GPU_SAMPLED_IMAGE` skips that copy entirely — that's the point of supporting both APIs.
@@ -133,5 +133,5 @@ Slice counts are deterministic to within ±1 per 10 s window: ~298 frames per re
 ## Other tooling worth knowing about
 
 - `vendor/android-skills/` — Google's official AI-optimized SKILL.md files for Android dev (Perfetto SQL, edge-to-edge, AGP upgrades, R8 analyzer, Macrobenchmark testing-setup, etc.). Browse `vendor/android-skills/<topic>/<skill>/SKILL.md` rather than guessing — every skill there has a precise scope statement at the top.
-- `vendor/jni.hpp/` — submodule for the Mapbox `jni.hpp` C++/JNI wrapper used by `core_engine.{hpp,cpp}`.
+- `vendor/jni.hpp/` — submodule for the Mapbox `jni.hpp` C++/JNI wrapper. Used by `core_engine.{hpp,cpp}` (native peer) and `frame_trace.{hpp,cpp}` (static-only via `STATIC_METHOD` from `util.hpp`).
 - `local.properties` is gitignored; the `sdk.dir` line is required for Gradle to find your SDK.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md — Camera Fast
+
+Project-wide notes for future sessions. Captures non-obvious context — architecture intent, instrumentation contracts, build gotchas, baseline findings. Read this before diving into code, especially before touching the camera→GPU pipeline or the build.
+
+## What this is
+
+Android demo app showing how to feed `AHardwareBuffer`s from the camera into both an **OpenGL ES 3** and a **Vulkan 1.3** renderer with zero CPU copies (when the buffer's `USAGE_GPU_SAMPLED_IMAGE` flag is set), then present to a `TextureView`. Almost all rendering lives in C++ via the NDK; Kotlin is glue + Compose UI.
+
+Single activity (`CameraActivity`). Default view is dual-pane — OpenGL preview on top, Vulkan preview on bottom — clickable to collapse one side. Edge-to-edge UI: previews go behind transparent system bars; the header label and bottom button row respect insets.
+
+## Architecture / data flow
+
+```
+CameraX (RGBA_8888) or Camera2 (PRIVATE)
+   ↓  (analyzer / OnImageAvailable, on a single worker thread)
+imageProxy.image.hardwareBuffer  +  FrameTrace.nextFrameId()
+   ↓  CoreEngine.sendCameraFrame()        ← one call per engine (GL + VK)
+nativeSendCameraFrame  (JNI)
+   ↓
+CoreEngine::nativeSendCameraFrame  (C++, worker thread)
+   ↓  GPU-sampled path:        renderer->processCameraFrame(buf, …, frameId)
+   ↓  CPU fallback path:       memcpy into a self-allocated GPU buffer, then same
+BaseRenderer::processCameraFrame
+   ↓  schedules a task on the renderer's LooperThread
+[render thread]
+   ↓  hwBufferToTexture()      ← becomes EGLImage / VkImage backed by external memory
+   ↓  postChoreographerCallback()
+[Choreographer doFrame on render thread]
+   ↓  renderImpl()             ← draws + eglSwapBuffers / vkQueuePresentKHR
+```
+
+Key files:
+- `app/src/main/java/com/dz/camerafast/CameraX.kt`, `Camera2.kt` — analyzer entry points.
+- `app/src/main/java/com/dz/camerafast/CoreEngine.kt` — Kotlin-side JNI surface + `TextureView.SurfaceTextureListener`.
+- `app/src/main/native/cpp/core_engine.{hpp,cpp}` — JNI peer; holds the renderer and the `ANativeWindow`.
+- `app/src/main/native/cpp/base_renderer.{hpp,cpp}` — render-thread Looper, frame-task scheduling, viewport/MVP coalescing, the `pendingPresentCookie` interlock.
+- `app/src/main/native/cpp/{opengl,vulkan}_renderer.{hpp,cpp}` — backend-specific code; the only place EGL/GL or Vulkan symbols are touched.
+
+The CPU fallback in `nativeSendCameraFrame` exists because **CameraX**'s `ImageAnalysis` delivers HW buffers with `USAGE_CPU_*` flags rather than `USAGE_GPU_SAMPLED_IMAGE`. We re-allocate a GPU buffer once, `memcpy` into it each frame (drops the engine mutex during the slow memcpy so main-thread JNI calls aren't blocked), then hand it to the renderer. Camera2 with `ImageFormat.PRIVATE` + `USAGE_GPU_SAMPLED_IMAGE` skips that copy entirely — that's the point of supporting both APIs.
+
+## Frame-timing instrumentation contract
+
+Per camera frame, the analyzer assigns a process-wide monotonic `frameId: Int` via `FrameTrace.nextFrameId()`. That id is the **cookie** of four ATrace async sections per renderer:
+
+| Section | Begin (where) | End (where) | What it measures |
+|---|---|---|---|
+| `dz.frame_to_native.<gl\|vk>` | Kotlin analyzer | `BaseRenderer::processCameraFrame` JNI entry | Kotlin glue overhead |
+| `dz.frame_native_proc.<gl\|vk>` | `processCameraFrame` entry | end of `hwBufferToTexture` on render thread | Native processing |
+| `dz.frame_to_screen.<gl\|vk>` | end of `hwBufferToTexture` | after `eglSwapBuffers` / `vkQueuePresentKHR` | Submit→present |
+| `dz.frame_e2e.<gl\|vk>` | Kotlin analyzer (same point as `to_native` begin) | swap/present returned | **End-to-end** |
+
+Section name constants live in two places that must stay in sync:
+- Kotlin: `app/src/main/java/com/dz/camerafast/FrameTrace.kt`
+- C++:    `app/src/main/native/cpp/frame_trace.hpp`
+
+Design decisions worth remembering:
+- **Cookie is an `Int`, not the sensor timestamp.** `android.os.Trace` cookies are 32-bit; sensor timestamps in nanoseconds overflow. A simple `AtomicInteger` counter avoids the collision risk that low-32-bit truncation would create.
+- **Superseded frames are deliberately dropped from `to_screen` / `e2e`.** When a newer frame's `hwBufferToTexture` overwrites `pendingPresentCookie` before Choreographer fires, the older frame's slices are left dangling — they won't appear in `slice` rows and won't pollute the latency distribution. By design.
+- **ATrace async APIs are API 29+; `minSdk` is 28.** `frame_trace.hpp` declares the symbols with `__attribute__((weak))`. On API 28 they resolve to `nullptr` and the helpers no-op cleanly; on 29+ the dynamic linker fills them in from `libandroid.so`.
+- **`-a com.dz.camerafast` is mandatory** when invoking `perfetto`. Without it, app-tag atrace sections (which is where these slices land) are filtered out and the trace processor returns zero rows. Both helper scripts always pass it; if you ever invoke `perfetto` by hand, don't forget.
+
+## Tooling — how to actually use this
+
+| What you want | Skill / Script |
+|---|---|
+| One-shot frame-latency measurement (single N-second capture) | `scripts/measure-frame-latency.sh [seconds]` |
+| Establish a baseline with dispersion (5 × 10s by default, JSON output) | `scripts/baseline-frame-latency.sh` — invokable via `/frame-latency-baseline` |
+| Build, install, launch, screenshot for visual verification of UI changes | `/verify-on-device` |
+| Discover Android-platform skills (camera, performance, perfetto-sql, etc.) | `vendor/android-skills/` submodule |
+
+All three scripts/skills assume a single ADB device. Set `ANDROID_SERIAL=<serial>` if multiple are attached. They auto-download Perfetto's `trace_processor` to `.cache/frame-latency/` (gitignored, ~25 MB) on first run.
+
+## Build / install gotchas
+
+These have bitten before; capture them so they don't bite again.
+
+- **`assembleDebug` fails for `armeabi-v7a`** because the repo ships `libs/shaderc/c++_static/{arm64-v8a,x86_64}/libshaderc.a` but not the v7a copy. Always limit to a single ABI:
+  ```bash
+  ./gradlew :app:installDebug -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')
+  ```
+- **Multi-display devices (foldables) corrupt `adb exec-out screencap`** by prefixing the PNG with a stdout warning. Pass `-d <display-id>` after discovering via `adb shell dumpsys SurfaceFlinger --display-id`. Trace capture is unaffected.
+- **Camera permission is gated by activity finish-on-deny.** Pre-grant it (`adb shell pm grant com.dz.camerafast android.permission.CAMERA`) when scripting; the helper scripts already do.
+- **Renderer state survives `am start`** without `force-stop`. The helper scripts always `force-stop` before launch, and `baseline-frame-latency.sh` also force-stops *between* runs so each iteration sees a cold app.
+
+## Baseline findings (SM-F936B / Android 16, arm64-v8a, 5 × 10 s)
+
+These are the numbers a future PR should be diffed against. Headline metric is `dz.frame_e2e.<gl|vk>` — full camera-arrival → on-screen latency.
+
+| Metric | mean | CV% (across 5 runs) |
+|---|---:|---:|
+| `frame_e2e.gl.avg` | 13.05 ms | 2.4% |
+| `frame_e2e.gl.p90` | 20.62 ms | 0.8% |
+| `frame_e2e.gl.p99` | 24.04 ms | 3.4% |
+| `frame_e2e.vk.avg` | 17.38 ms | 1.4% |
+| `frame_e2e.vk.p90` | 25.27 ms | 1.5% |
+| `frame_e2e.vk.p99` | 29.31 ms | 5.0% |
+| `frame_to_screen.gl.p90` | 17.79 ms | 1.3% |
+| `frame_to_screen.vk.p90` | 20.12 ms | 0.8% |
+
+OpenGL is consistently ~4 ms faster end-to-end (`frame_e2e` p90 20.6 ms vs 25.3 ms). Most of e2e is `frame_to_screen` — i.e. wait for the next vsync — so the GL/VK gap mainly reflects `frame_native_proc.vk.avg ≈ 3.2 ms` vs `gl.avg ≈ 1.1 ms` (Vulkan's hwBuffer → vkImage path has more setup).
+
+**Which metrics to gate PRs on:**
+- **Tight (±5%)**: `frame_e2e.{gl,vk}.{avg, p90}`, `frame_to_screen.{gl,vk}.p90`. All sub-2% CV.
+- **Looser (±10%)**: `frame_e2e.{gl,vk}.p99`, `frame_native_proc.{gl,vk}.avg`. CV 3–7%.
+- **Watch only, no gate**: `frame_native_proc.{gl,vk}.{p90, p99}` (6–16% CV).
+- **Skip entirely**: every `max` (single-outlier sensitive, 10–30% CV), and `p50` on screen-facing stages (bimodal — submit-to-vsync alignment).
+
+Slice counts are deterministic to within ±1 per 10 s window: ~298 frames per renderer (~30 fps from camera). A meaningful deviation in count is itself a regression signal — the renderer dropped frames before present.
+
+## Planned next steps (not yet implemented)
+
+- **Macrobenchmark module** wrapping the same capture flow with `TraceSectionMetric`, so the run produces the JSON straight from a Gradle task rather than a bash wrapper. The `testing/testing-setup` skill in `vendor/android-skills/` is the entry point for scaffolding.
+- **CI gate via GitHub Actions** running the macrobenchmark on either Firebase Test Lab (real hardware, paid per device-minute) or Gradle Managed Devices (emulator on the GHA runner, free but GPU≠real). Likely GMD for speed, with periodic FTL runs for trend tracking. The PR check diffs against a `baseline.json` checked into the repo and fails on regressions outside the gates listed above.
+
+## Other tooling worth knowing about
+
+- `vendor/android-skills/` — Google's official AI-optimized SKILL.md files for Android dev (Perfetto SQL, edge-to-edge, AGP upgrades, R8 analyzer, Macrobenchmark testing-setup, etc.). Browse `vendor/android-skills/<topic>/<skill>/SKILL.md` rather than guessing — every skill there has a precise scope statement at the top.
+- `vendor/jni.hpp/` — submodule for the Mapbox `jni.hpp` C++/JNI wrapper used by `core_engine.{hpp,cpp}`.
+- `local.properties` is gitignored; the `sdk.dir` line is required for Gradle to find your SDK.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,24 +44,33 @@ The CPU fallback in `nativeSendCameraFrame` exists because **CameraX**'s `ImageA
 
 ## Frame-timing instrumentation contract
 
-Per camera frame, the analyzer assigns a process-wide monotonic `frameId: Int` via `FrameTrace.nextFrameId()`. That id is the **cookie** of four ATrace async sections per renderer:
+Per camera frame, the analyzer assigns a process-wide monotonic `frameId: Int` via `FrameTrace.nextFrameId()`. That id is the **cookie** of four ATrace **async** sections per renderer, plus one **sync** sub-section nested inside the renderer's `renderImpl`:
 
-| Section | Begin (where) | End (where) | What it measures |
-|---|---|---|---|
-| `dz.frame_to_native.<gl\|vk>` | Kotlin analyzer | `BaseRenderer::processCameraFrame` JNI entry | Kotlin glue overhead |
-| `dz.frame_native_proc.<gl\|vk>` | `processCameraFrame` entry | end of `hwBufferToTexture` on render thread | Native processing |
-| `dz.frame_to_screen.<gl\|vk>` | end of `hwBufferToTexture` | after `eglSwapBuffers` / `vkQueuePresentKHR` | Submit→present |
-| `dz.frame_e2e.<gl\|vk>` | Kotlin analyzer (same point as `to_native` begin) | swap/present returned | **End-to-end** |
+| Section | Kind | Begin (where) | End (where) | What it measures |
+|---|---|---|---|---|
+| `dz.frame_to_native.<gl\|vk>` | async | Kotlin analyzer | `BaseRenderer::processCameraFrame` JNI entry | Kotlin glue overhead |
+| `dz.frame_native_proc.<gl\|vk>` | async | `processCameraFrame` entry | end of `hwBufferToTexture` on render thread | Native processing |
+| `dz.frame_to_screen.<gl\|vk>` | async | end of `hwBufferToTexture` | after `eglSwapBuffers` / `vkQueuePresentKHR` | Submit→present (mostly vsync wait at 60 Hz vs 30 fps camera) |
+| `dz.frame_render.<gl\|vk>` | sync | `renderImpl` entry | just before `eglSwapBuffers` / `vkQueuePresentKHR` | Actual GPU command submission only — subtract from `frame_to_screen` to isolate vsync wait |
+| `dz.frame_e2e.<gl\|vk>` | async | Kotlin analyzer (same point as `to_native` begin) | swap/present returned | **End-to-end** |
 
-Section name constants live in two places that must stay in sync:
+A counter track tracks dropped frames per renderer:
+
+| Counter | When incremented |
+|---|---|
+| `dz.dropped_frames.<gl\|vk>` | When a newer camera frame's texture is staged before the previous one's Choreographer callback fires |
+
+Section + counter name constants live in two places that must stay in sync:
 - Kotlin: `app/src/main/java/com/dz/camerafast/FrameTrace.kt`
 - C++:    `app/src/main/native/cpp/frame_trace.hpp`
 
 Design decisions worth remembering:
 - **Cookie is an `Int`, not the sensor timestamp.** `android.os.Trace` cookies are 32-bit; sensor timestamps in nanoseconds overflow. A simple `AtomicInteger` counter avoids the collision risk that low-32-bit truncation would create.
-- **Superseded frames are deliberately dropped from `to_screen` / `e2e`.** When a newer frame's `hwBufferToTexture` overwrites `pendingPresentCookie` before Choreographer fires, the older frame's slices are left dangling — they won't appear in `slice` rows and won't pollute the latency distribution. By design.
+- **Superseded frames' async slices are closed at the supersede point, not left dangling.** This keeps the Perfetto UI clean (no slices extending to infinity). The closed-on-supersede durations are within ~1/N of completed frames so they barely perturb aggregate stats; the `dropped_frames` counter remains the authoritative drop count.
+- **`dz.frame_render` is a sync section** because both begin and end happen on the render thread within a single function. Use sync (not async) when the section doesn't cross threads, doesn't overlap with others of the same name, and doesn't need per-instance identification — sync sections are slightly cheaper and don't need a cookie.
 - **ATrace async APIs are API 29+; `minSdk` is 29 to match.** No weak-linking dance — `frame_trace.hpp` includes `<android/trace.h>` and calls `ATrace_beginAsyncSection` / `endAsyncSection` directly. If `minSdk` ever drops below 29 again, the helpers will need to come back as weak symbols.
 - **`-a com.dz.camerafast` is mandatory** when invoking `perfetto`. Without it, app-tag atrace sections (which is where these slices land) are filtered out and the trace processor returns zero rows. Both helper scripts always pass it; if you ever invoke `perfetto` by hand, don't forget.
+- **Profileable for release.** `AndroidManifest.xml` declares `<profileable android:shell="true"/>` inside `<application>` so Perfetto can attach to a release build without it being `debuggable`. Always measure on release (`installRelease`) — debug NDK builds add ~50–100% overhead to the C++ paths, which would skew the baseline.
 
 ## Tooling — how to actually use this
 
@@ -78,38 +87,45 @@ All three scripts/skills assume a single ADB device. Set `ANDROID_SERIAL=<serial
 
 These have bitten before; capture them so they don't bite again.
 
-- **`assembleDebug` fails for `armeabi-v7a`** because the repo ships `libs/shaderc/c++_static/{arm64-v8a,x86_64}/libshaderc.a` but not the v7a copy. Always limit to a single ABI:
+- **Use `installRelease` for any latency measurement** — debug builds add significant NDK overhead. The release build is signed with the debug keystore (`signingConfig signingConfigs.debug` in `app/build.gradle`) so it installs locally without provisioning a real keystore.
+- **`assembleDebug` / `assembleRelease` both fail for `armeabi-v7a`** because the repo ships `libs/shaderc/c++_static/{arm64-v8a,x86_64}/libshaderc.a` but not the v7a copy. Always limit to a single ABI:
   ```bash
-  ./gradlew :app:installDebug -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')
+  ./gradlew :app:installRelease -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')
   ```
 - **Multi-display devices (foldables) corrupt `adb exec-out screencap`** by prefixing the PNG with a stdout warning. Pass `-d <display-id>` after discovering via `adb shell dumpsys SurfaceFlinger --display-id`. Trace capture is unaffected.
 - **Camera permission is gated by activity finish-on-deny.** Pre-grant it (`adb shell pm grant com.dz.camerafast android.permission.CAMERA`) when scripting; the helper scripts already do.
 - **Renderer state survives `am start`** without `force-stop`. The helper scripts always `force-stop` before launch, and `baseline-frame-latency.sh` also force-stops *between* runs so each iteration sees a cold app.
 
-## Baseline findings (SM-F936B / Android 16, arm64-v8a, 5 × 10 s)
+## Baseline findings (SM-F936B / Android 16, arm64-v8a, release build, 5 × 10 s)
 
-These are the numbers a future PR should be diffed against. Headline metric is `dz.frame_e2e.<gl|vk>` — full camera-arrival → on-screen latency.
+These are the numbers a future PR should be diffed against. Headline metric is `dz.frame_e2e.<gl|vk>` — full camera-arrival → on-screen latency. JSON form at `.cache/frame-latency/baseline.json`.
 
 | Metric | mean | CV% (across 5 runs) |
 |---|---:|---:|
-| `frame_e2e.gl.avg` | 13.05 ms | 2.4% |
-| `frame_e2e.gl.p90` | 20.62 ms | 0.8% |
-| `frame_e2e.gl.p99` | 24.04 ms | 3.4% |
-| `frame_e2e.vk.avg` | 17.38 ms | 1.4% |
-| `frame_e2e.vk.p90` | 25.27 ms | 1.5% |
-| `frame_e2e.vk.p99` | 29.31 ms | 5.0% |
-| `frame_to_screen.gl.p90` | 17.79 ms | 1.3% |
-| `frame_to_screen.vk.p90` | 20.12 ms | 0.8% |
+| `frame_e2e.gl.avg` | 13.25 ms | 1.8% |
+| `frame_e2e.gl.p90` | 20.72 ms | 1.4% |
+| `frame_e2e.gl.p99` | 23.45 ms | 1.3% |
+| `frame_e2e.vk.avg` | 14.91 ms | 1.3% |
+| `frame_e2e.vk.p90` | 22.48 ms | 1.0% |
+| `frame_e2e.vk.p99` | 25.50 ms | 2.6% |
+| `frame_to_screen.gl.p90` | 18.42 ms | 0.8% |
+| `frame_to_screen.vk.p90` | 19.02 ms | 1.0% |
+| `frame_render.gl.avg` | 0.57 ms | 6.4% |
+| `frame_render.vk.avg` | 1.76 ms | 5.0% |
+| `frame_native_proc.gl.avg` | 0.73 ms | 6.2% |
+| `frame_native_proc.vk.avg` | 1.66 ms | 2.4% |
 
-OpenGL is consistently ~4 ms faster end-to-end (`frame_e2e` p90 20.6 ms vs 25.3 ms). Most of e2e is `frame_to_screen` — i.e. wait for the next vsync — so the GL/VK gap mainly reflects `frame_native_proc.vk.avg ≈ 3.2 ms` vs `gl.avg ≈ 1.1 ms` (Vulkan's hwBuffer → vkImage path has more setup).
+OpenGL is ~1.7 ms faster end-to-end on average (`frame_e2e` avg 13.25 vs 14.91), and ~1.8 ms faster at p90 (20.7 vs 22.5). The gap is split between `frame_render` (GL 0.57 vs VK 1.76) and `frame_native_proc` (GL 0.73 vs VK 1.66) — Vulkan's hwBuffer → vkImage path and `vkAcquireNextImageKHR + submit + fence wait` both cost more than the OpenGL equivalents.
+
+**Most of `frame_to_screen` is vsync wait.** `frame_to_screen.gl.avg ≈ 10.9 ms` but only ~0.57 ms of that is actual GL command submission (`frame_render.gl.avg`); the remaining ~10.3 ms is Choreographer/vsync wait. Same shape for Vulkan: ~11.7 ms total vs ~1.76 ms of work. Optimizations that shave µs off GL/VK commands won't move the e2e needle until the vsync wait is what we're trying to displace (e.g. higher refresh rate, lower-latency presentation extensions).
 
 **Which metrics to gate PRs on:**
-- **Tight (±5%)**: `frame_e2e.{gl,vk}.{avg, p90}`, `frame_to_screen.{gl,vk}.p90`. All sub-2% CV.
-- **Looser (±10%)**: `frame_e2e.{gl,vk}.p99`, `frame_native_proc.{gl,vk}.avg`. CV 3–7%.
-- **Watch only, no gate**: `frame_native_proc.{gl,vk}.{p90, p99}` (6–16% CV).
-- **Skip entirely**: every `max` (single-outlier sensitive, 10–30% CV), and `p50` on screen-facing stages (bimodal — submit-to-vsync alignment).
+- **Tight (±5%)**: `frame_e2e.{gl,vk}.{avg, p90, p99}`, `frame_to_screen.{gl,vk}.p90`. All sub-3% CV.
+- **Looser (±10%)**: `frame_render.{gl,vk}.avg`, `frame_native_proc.{gl,vk}.avg`. CV 2–7%.
+- **Watch only, no gate**: `frame_native_proc.{gl,vk}.{p90, p99}` and `frame_render.{gl,vk}.{p90, p99}` (5–25% CV — single-tail-sample noise).
+- **Skip entirely**: every `max` (single-outlier sensitive, 15–40% CV), and `p50` on screen-facing stages (bimodal — submit-to-vsync alignment).
 
-Slice counts are deterministic to within ±1 per 10 s window: ~298 frames per renderer (~30 fps from camera). A meaningful deviation in count is itself a regression signal — the renderer dropped frames before present.
+Slice counts are deterministic to within ±1 per 10 s window: ~298 frames per renderer (~30 fps from camera). A meaningful deviation in count is itself a regression signal.
 
 ## Planned next steps (not yet implemented)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,10 @@ A counter track tracks dropped frames per renderer:
 |---|---|
 | `dz.dropped_frames.<gl\|vk>` | When a newer camera frame's texture is staged before the previous one's Choreographer callback fires |
 
-Section + counter name constants live in two places that must stay in sync:
-- Kotlin: `app/src/main/java/com/dz/camerafast/FrameTrace.kt`
-- C++:    `app/src/main/native/cpp/frame_trace.hpp`
+Section + counter name constants live in **one** place — `app/src/main/native/cpp/frame_trace.hpp`. The Kotlin `FrameTrace` object exposes `@JvmStatic external` methods backed by `app/src/main/native/cpp/frame_trace.cpp`; its `FRAME_E2E_GL` / `FRAME_E2E_VK` / `FRAME_TO_NATIVE_GL` / `FRAME_TO_NATIVE_VK` `@JvmField val`s are populated from C++ at class-load. Don't add new constants to Kotlin — extend `traceNames` in `frame_trace.hpp` and add a getter.
 
 Design decisions worth remembering:
-- **Cookie is an `Int`, not the sensor timestamp.** `android.os.Trace` cookies are 32-bit; sensor timestamps in nanoseconds overflow. A simple `AtomicInteger` counter avoids the collision risk that low-32-bit truncation would create.
+- **`frameId` is an `Int`, not the sensor timestamp.** ATrace's async-section cookie is 32-bit; sensor timestamps in nanoseconds overflow. A `std::atomic<int32_t>` in `frame_trace.cpp` (exposed as `FrameTrace.nextFrameId()`) avoids that. We use `frameId` rather than "cookie" in our wrappers because we always pass a frame number; the term "cookie" is only kept where the underlying ATrace API uses it.
 - **Superseded frames' async slices are closed at the supersede point, not left dangling.** This keeps the Perfetto UI clean (no slices extending to infinity). The closed-on-supersede durations are within ~1/N of completed frames so they barely perturb aggregate stats; the `dropped_frames` counter remains the authoritative drop count.
 - **`dz.frame_render` is a sync section** because both begin and end happen on the render thread within a single function. Use sync (not async) when the section doesn't cross threads, doesn't overlap with others of the same name, and doesn't need per-instance identification — sync sections are slightly cheaper and don't need a cookie.
 - **ATrace async APIs are API 29+; `minSdk` is 29 to match.** No weak-linking dance — `frame_trace.hpp` includes `<android/trace.h>` and calls `ATrace_beginAsyncSection` / `endAsyncSection` directly. If `minSdk` ever drops below 29 again, the helpers will need to come back as weak symbols.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Project-wide notes for future sessions. Captures non-obvious context — architecture intent, instrumentation contracts, build gotchas, baseline findings. Read this before diving into code, especially before touching the camera→GPU pipeline or the build.
 
+## Code style
+
+Default to no comments. Only add one when the *why* isn't obvious from the code — a non-trivial invariant, a thread/race subtlety, a cross-file contract, or a workaround. Identifiers carry the *what*; long block-comments explaining the *what* are noise. If you find yourself writing one, ask whether the explanation belongs in this file (architecture / design intent) or a skill (workflow steps) instead.
+
 ## What this is
 
 Android demo app showing how to feed `AHardwareBuffer`s from the camera into both an **OpenGL ES 3** and a **Vulkan 1.3** renderer with zero CPU copies (when the buffer's `USAGE_GPU_SAMPLED_IMAGE` flag is set), then present to a `TextureView`. Almost all rendering lives in C++ via the NDK; Kotlin is glue + Compose UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Section name constants live in two places that must stay in sync:
 Design decisions worth remembering:
 - **Cookie is an `Int`, not the sensor timestamp.** `android.os.Trace` cookies are 32-bit; sensor timestamps in nanoseconds overflow. A simple `AtomicInteger` counter avoids the collision risk that low-32-bit truncation would create.
 - **Superseded frames are deliberately dropped from `to_screen` / `e2e`.** When a newer frame's `hwBufferToTexture` overwrites `pendingPresentCookie` before Choreographer fires, the older frame's slices are left dangling — they won't appear in `slice` rows and won't pollute the latency distribution. By design.
-- **ATrace async APIs are API 29+; `minSdk` is 28.** `frame_trace.hpp` declares the symbols with `__attribute__((weak))`. On API 28 they resolve to `nullptr` and the helpers no-op cleanly; on 29+ the dynamic linker fills them in from `libandroid.so`.
+- **ATrace async APIs are API 29+; `minSdk` is 29 to match.** No weak-linking dance — `frame_trace.hpp` includes `<android/trace.h>` and calls `ATrace_beginAsyncSection` / `endAsyncSection` directly. If `minSdk` ever drops below 29 again, the helpers will need to come back as weak symbols.
 - **`-a com.dz.camerafast` is mandatory** when invoking `perfetto`. Without it, app-tag atrace sections (which is where these slices land) are filtered out and the trace processor returns zero rows. Both helper scripts always pass it; if you ever invoke `perfetto` by hand, don't forget.
 
 ## Tooling — how to actually use this

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
         app/src/main/native/cpp/main.cpp
         app/src/main/native/cpp/base_renderer.cpp
         app/src/main/native/cpp/core_engine.cpp
+        app/src/main/native/cpp/frame_trace.cpp
         app/src/main/native/cpp/opengl_renderer.cpp
         app/src/main/native/cpp/vulkan_renderer.cpp
         app/src/main/native/cpp/vulkan_wrapper.cpp

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.dz.camerafast"
-        minSdk 28
+        minSdk 29
         targetSdk 35
         versionCode 1
         versionName "1.0"
@@ -24,7 +24,7 @@ android {
             ndk {
                 externalNativeBuild {
                     cmake.arguments '-DANDROID_STL=c++_static',
-                            '-DANDROID_PLATFORM=android-28',
+                            '-DANDROID_PLATFORM=android-29',
                             '-DANDROID_TOOLCHAIN=clang',
                             '-DCMAKE_BUILD_TYPE=Release'
                 }
@@ -34,7 +34,7 @@ android {
             ndk {
                 externalNativeBuild {
                     cmake.arguments '-DANDROID_STL=c++_static',
-                            '-DANDROID_PLATFORM=android-28',
+                            '-DANDROID_PLATFORM=android-29',
                             '-DANDROID_TOOLCHAIN=clang',
                             '-DCMAKE_BUILD_TYPE=Debug'
                 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,7 @@ android {
     ndkVersion = '25.1.8937393'
     buildTypes {
         release {
+            signingConfig signingConfigs.debug
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             ndk {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CameraFast">
+        <profileable android:shell="true" />
         <activity
             android:name=".CameraActivity"
             android:screenOrientation="portrait"

--- a/app/src/main/java/com/dz/camerafast/Camera2.kt
+++ b/app/src/main/java/com/dz/camerafast/Camera2.kt
@@ -117,11 +117,15 @@ fun Camera2(
         {
           val image: Image? = it.acquireLatestImage()
           image?.hardwareBuffer?.let { buffer ->
+            val frameId = FrameTrace.nextFrameId()
             coreEngines.forEach { engine ->
+              FrameTrace.beginE2E(engine.renderingMode, frameId)
+              FrameTrace.beginToNative(engine.renderingMode, frameId)
               engine.sendCameraFrame(
                 buffer = buffer,
                 rotationDegrees = rotationDegrees,
-                backCamera = lensFacing == CameraSelector.LENS_FACING_BACK
+                backCamera = lensFacing == CameraSelector.LENS_FACING_BACK,
+                frameId = frameId
               )
             }
             buffer.close()

--- a/app/src/main/java/com/dz/camerafast/CameraX.kt
+++ b/app/src/main/java/com/dz/camerafast/CameraX.kt
@@ -44,11 +44,15 @@ fun CameraX(
       imageAnalysis.setAnalyzer(Executors.newSingleThreadExecutor()) { imageProxy ->
         Log.i(TAG, "New image ${imageProxy.hashCode()} arrived!")
         imageProxy.image?.hardwareBuffer?.let { buffer ->
-          coreEngines.forEach {
-            it.sendCameraFrame(
+          val frameId = FrameTrace.nextFrameId()
+          coreEngines.forEach { engine ->
+            FrameTrace.beginE2E(engine.renderingMode, frameId)
+            FrameTrace.beginToNative(engine.renderingMode, frameId)
+            engine.sendCameraFrame(
               buffer = buffer,
               rotationDegrees = imageProxy.imageInfo.rotationDegrees,
-              backCamera = lensFacing == CameraSelector.LENS_FACING_BACK
+              backCamera = lensFacing == CameraSelector.LENS_FACING_BACK,
+              frameId = frameId
             )
           }
           buffer.close()

--- a/app/src/main/java/com/dz/camerafast/CoreEngine.kt
+++ b/app/src/main/java/com/dz/camerafast/CoreEngine.kt
@@ -32,9 +32,9 @@ class CoreEngine(
     initialize(renderingMode.ordinal)
   }
 
-  fun sendCameraFrame(buffer: HardwareBuffer, rotationDegrees: Int, backCamera: Boolean) {
+  fun sendCameraFrame(buffer: HardwareBuffer, rotationDegrees: Int, backCamera: Boolean, frameId: Int) {
     buffer.printSupportedUsageFlags()
-    nativeSendCameraFrame(buffer, rotationDegrees, backCamera)
+    nativeSendCameraFrame(buffer, rotationDegrees, backCamera, frameId)
   }
 
   private var previousWeight: Float = 1.0f
@@ -94,7 +94,8 @@ class CoreEngine(
   private external fun nativeSendCameraFrame(
     buffer: HardwareBuffer,
     rotationDegrees: Int,
-    backCamera: Boolean
+    backCamera: Boolean,
+    frameId: Int
   )
 
   private external fun nativeRefit()

--- a/app/src/main/java/com/dz/camerafast/FrameTrace.kt
+++ b/app/src/main/java/com/dz/camerafast/FrameTrace.kt
@@ -1,0 +1,35 @@
+package com.dz.camerafast
+
+import android.os.Trace
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Per-frame Perfetto/atrace instrumentation. Section names follow the convention
+ * `dz.<stage>.<gl|vk>` so each renderer is metered independently.
+ *
+ * Frame ids are a process-wide monotonic Int counter (not the sensor timestamp) because
+ * android.os.Trace cookies are 32-bit. The Int wraps after ~2.1B frames, which we never reach.
+ */
+object FrameTrace {
+
+  private val nextId = AtomicInteger(0)
+
+  fun nextFrameId(): Int = nextId.incrementAndGet()
+
+  fun e2eName(mode: RenderingMode): String = "dz.frame_e2e.${mode.suffix}"
+  fun toNativeName(mode: RenderingMode): String = "dz.frame_to_native.${mode.suffix}"
+
+  fun beginE2E(mode: RenderingMode, frameId: Int) {
+    Trace.beginAsyncSection(e2eName(mode), frameId)
+  }
+
+  fun beginToNative(mode: RenderingMode, frameId: Int) {
+    Trace.beginAsyncSection(toNativeName(mode), frameId)
+  }
+
+  private val RenderingMode.suffix: String
+    get() = when (this) {
+      RenderingMode.OPEN_GL_ES -> "gl"
+      RenderingMode.VULKAN -> "vk"
+    }
+}

--- a/app/src/main/java/com/dz/camerafast/FrameTrace.kt
+++ b/app/src/main/java/com/dz/camerafast/FrameTrace.kt
@@ -1,29 +1,31 @@
 package com.dz.camerafast
 
-import android.os.Trace
-import java.util.concurrent.atomic.AtomicInteger
+import androidx.annotation.Keep
 
+@Keep
 object FrameTrace {
 
-  // Trace cookies are 32-bit; sensor timestamps overflow Int. Plain counter instead.
-  private val nextId = AtomicInteger(0)
-
-  fun nextFrameId(): Int = nextId.incrementAndGet()
-
-  fun e2eName(mode: RenderingMode): String = "dz.frame_e2e.${mode.suffix}"
-  fun toNativeName(mode: RenderingMode): String = "dz.frame_to_native.${mode.suffix}"
-
-  fun beginE2E(mode: RenderingMode, frameId: Int) {
-    Trace.beginAsyncSection(e2eName(mode), frameId)
+  init {
+    System.loadLibrary("native-engine")
   }
 
-  fun beginToNative(mode: RenderingMode, frameId: Int) {
-    Trace.beginAsyncSection(toNativeName(mode), frameId)
-  }
+  @JvmField val FRAME_E2E_GL: String = frameE2EGlName()
+  @JvmField val FRAME_E2E_VK: String = frameE2EVkName()
+  @JvmField val FRAME_TO_NATIVE_GL: String = frameToNativeGlName()
+  @JvmField val FRAME_TO_NATIVE_VK: String = frameToNativeVkName()
 
-  private val RenderingMode.suffix: String
-    get() = when (this) {
-      RenderingMode.OPEN_GL_ES -> "gl"
-      RenderingMode.VULKAN -> "vk"
-    }
+  @JvmStatic external fun nextFrameId(): Int
+  @JvmStatic external fun traceBeginAsync(name: String, frameId: Int)
+  @JvmStatic external fun traceEndAsync(name: String, frameId: Int)
+
+  fun beginE2E(mode: RenderingMode, frameId: Int) =
+    traceBeginAsync(if (mode == RenderingMode.VULKAN) FRAME_E2E_VK else FRAME_E2E_GL, frameId)
+
+  fun beginToNative(mode: RenderingMode, frameId: Int) =
+    traceBeginAsync(if (mode == RenderingMode.VULKAN) FRAME_TO_NATIVE_VK else FRAME_TO_NATIVE_GL, frameId)
+
+  @JvmStatic private external fun frameE2EGlName(): String
+  @JvmStatic private external fun frameE2EVkName(): String
+  @JvmStatic private external fun frameToNativeGlName(): String
+  @JvmStatic private external fun frameToNativeVkName(): String
 }

--- a/app/src/main/java/com/dz/camerafast/FrameTrace.kt
+++ b/app/src/main/java/com/dz/camerafast/FrameTrace.kt
@@ -16,7 +16,6 @@ object FrameTrace {
 
   @JvmStatic external fun nextFrameId(): Int
   @JvmStatic external fun traceBeginAsync(name: String, frameId: Int)
-  @JvmStatic external fun traceEndAsync(name: String, frameId: Int)
 
   fun beginE2E(mode: RenderingMode, frameId: Int) =
     traceBeginAsync(if (mode == RenderingMode.VULKAN) FRAME_E2E_VK else FRAME_E2E_GL, frameId)

--- a/app/src/main/java/com/dz/camerafast/FrameTrace.kt
+++ b/app/src/main/java/com/dz/camerafast/FrameTrace.kt
@@ -3,15 +3,9 @@ package com.dz.camerafast
 import android.os.Trace
 import java.util.concurrent.atomic.AtomicInteger
 
-/**
- * Per-frame Perfetto/atrace instrumentation. Section names follow the convention
- * `dz.<stage>.<gl|vk>` so each renderer is metered independently.
- *
- * Frame ids are a process-wide monotonic Int counter (not the sensor timestamp) because
- * android.os.Trace cookies are 32-bit. The Int wraps after ~2.1B frames, which we never reach.
- */
 object FrameTrace {
 
+  // Trace cookies are 32-bit; sensor timestamps overflow Int. Plain counter instead.
   private val nextId = AtomicInteger(0)
 
   fun nextFrameId(): Int = nextId.incrementAndGet()

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -1,5 +1,7 @@
 #include "base_renderer.hpp"
 
+#include "frame_trace.hpp"
+
 namespace engine {
 namespace android {
 
@@ -143,10 +145,16 @@ void BaseRenderer::updateMvp() {
 }
 
 void BaseRenderer::processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rotationDegrees_,
-                                      bool backCamera_) {
+                                      bool backCamera_, int32_t frameId) {
+  // The Kotlin side opened dz.frame_to_native.<suffix> for this frameId. Close it now that
+  // we've crossed JNI, and open the native-processing slice (run on the camera worker thread
+  // up to the point where the render thread is about to start hwBufferToTexture).
+  traceEndAsync(frameToNativeSectionName(), frameId);
+  traceBeginAsync(frameNativeProcSectionName(), frameId);
+
   AHardwareBuffer_acquire(aHardwareBuffer);
   LOGI("Buffer %p acquired by %s renderer" , aHardwareBuffer, this->renderingModeName());
-  renderThread->scheduleTask([aHardwareBuffer, rotationDegrees_, backCamera_, this] {
+  renderThread->scheduleTask([aHardwareBuffer, rotationDegrees_, backCamera_, frameId, this] {
     AHardwareBuffer_Desc description;
     AHardwareBuffer_describe(aHardwareBuffer, &description);
     const auto bufferImageRatio_ =
@@ -169,6 +177,16 @@ void BaseRenderer::processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rota
     AHardwareBuffer_release(aHardwareBuffer);
     LOGI("Buffer %p released by %s renderer" , aHardwareBuffer, this->renderingModeName());
     bufferMutex.unlock();
+
+    // Texture/vkImage is now ready. Close the native-processing slice and open the
+    // submit→present slice. The renderer's renderImpl() will close it after eglSwapBuffers /
+    // vkQueuePresentKHR. If a newer frame is staged before the Choreographer fires, its cookie
+    // will overwrite pendingPresentCookie and the older frame's slices will be left dangling
+    // — which is the correct behavior (a dropped frame should not contribute to latency p99).
+    traceEndAsync(frameNativeProcSectionName(), frameId);
+    traceBeginAsync(frameToScreenSectionName(), frameId);
+    pendingPresentCookie = frameId;
+
     // post choreographer callback as we will need to render this texture
     postChoreographerCallback();
   });

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -146,9 +146,6 @@ void BaseRenderer::updateMvp() {
 
 void BaseRenderer::processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rotationDegrees_,
                                       bool backCamera_, int32_t frameId) {
-  // The Kotlin side opened dz.frame_to_native.<suffix> for this frameId. Close it now that
-  // we've crossed JNI, and open the native-processing slice (run on the camera worker thread
-  // up to the point where the render thread is about to start hwBufferToTexture).
   traceEndAsync(frameToNativeSectionName(), frameId);
   traceBeginAsync(frameNativeProcSectionName(), frameId);
 
@@ -178,16 +175,12 @@ void BaseRenderer::processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rota
     LOGI("Buffer %p released by %s renderer" , aHardwareBuffer, this->renderingModeName());
     bufferMutex.unlock();
 
-    // Texture/vkImage is now ready. Close the native-processing slice and open the
-    // submit→present slice. The renderer's renderImpl() will close it after eglSwapBuffers /
-    // vkQueuePresentKHR. If a newer frame is staged before the Choreographer fires, its cookie
-    // will overwrite pendingPresentCookie and the older frame's slices will be left dangling
-    // — which is the correct behavior (a dropped frame should not contribute to latency p99).
     traceEndAsync(frameNativeProcSectionName(), frameId);
     traceBeginAsync(frameToScreenSectionName(), frameId);
+    // If superseded before present, the older cookie's slices stay open and don't appear in
+    // the trace — dropped frames are intentionally excluded from latency stats.
     pendingPresentCookie = frameId;
 
-    // post choreographer callback as we will need to render this texture
     postChoreographerCallback();
   });
 }

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -177,8 +177,15 @@ void BaseRenderer::processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rota
 
     traceEndAsync(frameNativeProcSectionName(), frameId);
     traceBeginAsync(frameToScreenSectionName(), frameId);
-    // If superseded before present, the older cookie's slices stay open and don't appear in
-    // the trace — dropped frames are intentionally excluded from latency stats.
+    if (pendingPresentCookie != -1) {
+      // Close the superseded frame's slices so the Perfetto UI doesn't render them as
+      // infinitely-open. The closed-on-supersede durations are roughly the same order of
+      // magnitude as completed frames and only perturb aggregate stats by ~1/N; the
+      // dropped_frames counter remains the source of truth for drop count.
+      traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
+      traceEndAsync(frameE2ESectionName(), pendingPresentCookie);
+      traceSetCounter(droppedFramesCounterName(), ++droppedFrames);
+    }
     pendingPresentCookie = frameId;
 
     postChoreographerCallback();

--- a/app/src/main/native/cpp/base_renderer.cpp
+++ b/app/src/main/native/cpp/base_renderer.cpp
@@ -177,16 +177,12 @@ void BaseRenderer::processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rota
 
     traceEndAsync(frameNativeProcSectionName(), frameId);
     traceBeginAsync(frameToScreenSectionName(), frameId);
-    if (pendingPresentCookie != -1) {
-      // Close the superseded frame's slices so the Perfetto UI doesn't render them as
-      // infinitely-open. The closed-on-supersede durations are roughly the same order of
-      // magnitude as completed frames and only perturb aggregate stats by ~1/N; the
-      // dropped_frames counter remains the source of truth for drop count.
-      traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
-      traceEndAsync(frameE2ESectionName(), pendingPresentCookie);
+    if (pendingPresentFrameId != kNoPendingFrame) {
+      traceEndAsync(frameToScreenSectionName(), pendingPresentFrameId);
+      traceEndAsync(frameE2ESectionName(), pendingPresentFrameId);
       traceSetCounter(droppedFramesCounterName(), ++droppedFrames);
     }
-    pendingPresentCookie = frameId;
+    pendingPresentFrameId = frameId;
 
     postChoreographerCallback();
   });

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -45,19 +45,13 @@ public:
 protected:
     virtual const char *renderingModeName() = 0;
 
-    // Suffix used in dz.frame_*.<suffix> ATrace section names; must be "gl" or "vk".
     virtual const char *traceSuffix() const = 0;
-
-    // Trace section names (cached per renderer).
     virtual const char *frameToNativeSectionName() const = 0;
     virtual const char *frameNativeProcSectionName() const = 0;
     virtual const char *frameToScreenSectionName() const = 0;
     virtual const char *frameE2ESectionName() const = 0;
 
-    // Cookie of the camera frame whose texture/vkImage is staged and waiting for present.
-    // Written from the render-thread task that closes hwBufferToTexture; read+cleared by the
-    // renderer's renderImpl() once the swap/present has happened. Both happen on the render
-    // thread, so a plain int is safe.
+    // Render-thread-only; no atomic needed.
     int32_t pendingPresentCookie = -1;
 
     virtual bool onWindowCreated() = 0;

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -21,7 +21,7 @@ class BaseRenderer {
 public:
     BaseRenderer();
 
-    ~BaseRenderer();
+    virtual ~BaseRenderer();
 
     void setWindow(ANativeWindow *window);
 
@@ -45,14 +45,15 @@ public:
 protected:
     virtual const char *renderingModeName() = 0;
 
-    virtual const char *traceSuffix() const = 0;
     virtual const char *frameToNativeSectionName() const = 0;
     virtual const char *frameNativeProcSectionName() const = 0;
     virtual const char *frameToScreenSectionName() const = 0;
     virtual const char *frameE2ESectionName() const = 0;
+    virtual const char *droppedFramesCounterName() const = 0;
 
     // Render-thread-only; no atomic needed.
     int32_t pendingPresentCookie = -1;
+    int64_t droppedFrames = 0;
 
     virtual bool onWindowCreated() = 0;
 

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -39,10 +39,26 @@ public:
      * Always called from camera worker thread - feed new camera buffer.
      * @param aHardwareBuffer
      */
-    void processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rotationDegrees_, bool backCamera_);
+    void processCameraFrame(AHardwareBuffer *aHardwareBuffer, int rotationDegrees_, bool backCamera_,
+                            int32_t frameId);
 
 protected:
     virtual const char *renderingModeName() = 0;
+
+    // Suffix used in dz.frame_*.<suffix> ATrace section names; must be "gl" or "vk".
+    virtual const char *traceSuffix() const = 0;
+
+    // Trace section names (cached per renderer).
+    virtual const char *frameToNativeSectionName() const = 0;
+    virtual const char *frameNativeProcSectionName() const = 0;
+    virtual const char *frameToScreenSectionName() const = 0;
+    virtual const char *frameE2ESectionName() const = 0;
+
+    // Cookie of the camera frame whose texture/vkImage is staged and waiting for present.
+    // Written from the render-thread task that closes hwBufferToTexture; read+cleared by the
+    // renderer's renderImpl() once the swap/present has happened. Both happen on the render
+    // thread, so a plain int is safe.
+    int32_t pendingPresentCookie = -1;
 
     virtual bool onWindowCreated() = 0;
 

--- a/app/src/main/native/cpp/base_renderer.hpp
+++ b/app/src/main/native/cpp/base_renderer.hpp
@@ -51,8 +51,10 @@ protected:
     virtual const char *frameE2ESectionName() const = 0;
     virtual const char *droppedFramesCounterName() const = 0;
 
+    static constexpr int32_t kNoPendingFrame = -1;
+
     // Render-thread-only; no atomic needed.
-    int32_t pendingPresentCookie = -1;
+    int32_t pendingPresentFrameId = kNoPendingFrame;
     int64_t droppedFrames = 0;
 
     virtual bool onWindowCreated() = 0;

--- a/app/src/main/native/cpp/core_engine.cpp
+++ b/app/src/main/native/cpp/core_engine.cpp
@@ -69,7 +69,8 @@ void CoreEngine::nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint 
 
 /** called from worker thread **/
 void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBuffer> &buffer,
-                                       jni::jint rotationDegrees, jni::jboolean backCamera) {
+                                       jni::jint rotationDegrees, jni::jboolean backCamera,
+                                       jni::jint frameId) {
   std::unique_lock<std::mutex> lock(coreEngineMutex);
   if (!renderer) {
     return;
@@ -78,7 +79,7 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
   AHardwareBuffer_Desc cameraBufferDescription;
   AHardwareBuffer_describe(cameraBuffer, &cameraBufferDescription);
   if (cameraBufferDescription.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) {
-    renderer->processCameraFrame(cameraBuffer, rotationDegrees, backCamera);
+    renderer->processCameraFrame(cameraBuffer, rotationDegrees, backCamera, frameId);
     return;
   }
   // CPU fallback: drop the mutex around the slow memcpy so main-thread JNI calls aren't blocked
@@ -113,7 +114,7 @@ void CoreEngine::nativeSendCameraFrame(JNIEnv &env, const jni::Object<HardwareBu
 
   lock.lock();
   if (renderer) {
-    renderer->processCameraFrame(localGpuBuffer, rotationDegrees, backCamera);
+    renderer->processCameraFrame(localGpuBuffer, rotationDegrees, backCamera, frameId);
   }
   AHardwareBuffer_release(localGpuBuffer);
 }

--- a/app/src/main/native/cpp/core_engine.hpp
+++ b/app/src/main/native/cpp/core_engine.hpp
@@ -60,7 +60,7 @@ public:
 
   void nativeUpdateWindowSize(JNIEnv &env, jni::jint width, jni::jint height);
 
-  void nativeSendCameraFrame(JNIEnv &env, jni::Object <HardwareBuffer> const &buffer, jni::jint rotationDegrees, jni::jboolean backCamera);
+  void nativeSendCameraFrame(JNIEnv &env, jni::Object <HardwareBuffer> const &buffer, jni::jint rotationDegrees, jni::jboolean backCamera, jni::jint frameId);
 
   void nativeRefit(JNIEnv &env);
 

--- a/app/src/main/native/cpp/frame_trace.cpp
+++ b/app/src/main/native/cpp/frame_trace.cpp
@@ -1,0 +1,41 @@
+#include "frame_trace.hpp"
+
+#include <string>
+
+namespace engine {
+namespace android {
+
+std::atomic<int32_t> FrameTrace::frameCounter{0};
+
+jni::jint FrameTrace::nextFrameId(jni::JNIEnv &, jni::Class<FrameTrace> &) {
+  return ++frameCounter;
+}
+
+void FrameTrace::traceBeginAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &,
+                                 const jni::String &name, jni::jint frameId) {
+  ::engine::android::traceBeginAsync(jni::Make<std::string>(env, name).c_str(), frameId);
+}
+
+void FrameTrace::traceEndAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &,
+                               const jni::String &name, jni::jint frameId) {
+  ::engine::android::traceEndAsync(jni::Make<std::string>(env, name).c_str(), frameId);
+}
+
+jni::Local<jni::String> FrameTrace::frameE2EGlName(jni::JNIEnv &env, jni::Class<FrameTrace> &) {
+  return jni::Make<jni::String>(env, std::string(traceNames::FRAME_E2E_GL));
+}
+
+jni::Local<jni::String> FrameTrace::frameE2EVkName(jni::JNIEnv &env, jni::Class<FrameTrace> &) {
+  return jni::Make<jni::String>(env, std::string(traceNames::FRAME_E2E_VK));
+}
+
+jni::Local<jni::String> FrameTrace::frameToNativeGlName(jni::JNIEnv &env, jni::Class<FrameTrace> &) {
+  return jni::Make<jni::String>(env, std::string(traceNames::FRAME_TO_NATIVE_GL));
+}
+
+jni::Local<jni::String> FrameTrace::frameToNativeVkName(jni::JNIEnv &env, jni::Class<FrameTrace> &) {
+  return jni::Make<jni::String>(env, std::string(traceNames::FRAME_TO_NATIVE_VK));
+}
+
+} // namespace android
+} // namespace engine

--- a/app/src/main/native/cpp/frame_trace.cpp
+++ b/app/src/main/native/cpp/frame_trace.cpp
@@ -16,11 +16,6 @@ void FrameTrace::traceBeginAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &,
   ::engine::android::traceBeginAsync(jni::Make<std::string>(env, name).c_str(), frameId);
 }
 
-void FrameTrace::traceEndAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &,
-                               const jni::String &name, jni::jint frameId) {
-  ::engine::android::traceEndAsync(jni::Make<std::string>(env, name).c_str(), frameId);
-}
-
 jni::Local<jni::String> FrameTrace::frameE2EGlName(jni::JNIEnv &env, jni::Class<FrameTrace> &) {
   return jni::Make<jni::String>(env, std::string(traceNames::FRAME_E2E_GL));
 }

--- a/app/src/main/native/cpp/frame_trace.hpp
+++ b/app/src/main/native/cpp/frame_trace.hpp
@@ -42,8 +42,6 @@ constexpr const char *FRAME_E2E_GL = "dz.frame_e2e.gl";
 constexpr const char *FRAME_E2E_VK = "dz.frame_e2e.vk";
 constexpr const char *DROPPED_FRAMES_GL = "dz.dropped_frames.gl";
 constexpr const char *DROPPED_FRAMES_VK = "dz.dropped_frames.vk";
-// Inner sync slice covering only the renderImpl work (draw+swap/present), so
-// frame_to_screen - frame_render approximates the Choreographer/vsync wait.
 constexpr const char *FRAME_RENDER_GL = "dz.frame_render.gl";
 constexpr const char *FRAME_RENDER_VK = "dz.frame_render.vk";
 } // namespace traceNames
@@ -57,7 +55,6 @@ public:
     jni::RegisterNatives(env, *jni::Class<FrameTrace>::Find(env),
             STATIC_METHOD(&FrameTrace::nextFrameId, "nextFrameId"),
             STATIC_METHOD(&FrameTrace::traceBeginAsync, "traceBeginAsync"),
-            STATIC_METHOD(&FrameTrace::traceEndAsync, "traceEndAsync"),
             STATIC_METHOD(&FrameTrace::frameE2EGlName, "frameE2EGlName"),
             STATIC_METHOD(&FrameTrace::frameE2EVkName, "frameE2EVkName"),
             STATIC_METHOD(&FrameTrace::frameToNativeGlName, "frameToNativeGlName"),
@@ -67,7 +64,6 @@ public:
 
   static jni::jint nextFrameId(jni::JNIEnv &env, jni::Class<FrameTrace> &);
   static void traceBeginAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &, const jni::String &name, jni::jint frameId);
-  static void traceEndAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &, const jni::String &name, jni::jint frameId);
   static jni::Local<jni::String> frameE2EGlName(jni::JNIEnv &env, jni::Class<FrameTrace> &);
   static jni::Local<jni::String> frameE2EVkName(jni::JNIEnv &env, jni::Class<FrameTrace> &);
   static jni::Local<jni::String> frameToNativeGlName(jni::JNIEnv &env, jni::Class<FrameTrace> &);

--- a/app/src/main/native/cpp/frame_trace.hpp
+++ b/app/src/main/native/cpp/frame_trace.hpp
@@ -15,6 +15,18 @@ inline void traceEndAsync(const char *name, int32_t cookie) {
   ATrace_endAsyncSection(name, cookie);
 }
 
+inline void traceSetCounter(const char *name, int64_t value) {
+  ATrace_setCounter(name, value);
+}
+
+inline void traceBeginSync(const char *name) {
+  ATrace_beginSection(name);
+}
+
+inline void traceEndSync() {
+  ATrace_endSection();
+}
+
 // Stable section names — must match com.dz.camerafast.FrameTrace on the Kotlin side.
 namespace traceNames {
 constexpr const char *FRAME_TO_NATIVE_GL = "dz.frame_to_native.gl";
@@ -25,6 +37,12 @@ constexpr const char *FRAME_TO_SCREEN_GL = "dz.frame_to_screen.gl";
 constexpr const char *FRAME_TO_SCREEN_VK = "dz.frame_to_screen.vk";
 constexpr const char *FRAME_E2E_GL = "dz.frame_e2e.gl";
 constexpr const char *FRAME_E2E_VK = "dz.frame_e2e.vk";
+constexpr const char *DROPPED_FRAMES_GL = "dz.dropped_frames.gl";
+constexpr const char *DROPPED_FRAMES_VK = "dz.dropped_frames.vk";
+// Inner sync slice covering only the renderImpl work (draw+swap/present), so
+// frame_to_screen - frame_render approximates the Choreographer/vsync wait.
+constexpr const char *FRAME_RENDER_GL = "dz.frame_render.gl";
+constexpr const char *FRAME_RENDER_VK = "dz.frame_render.vk";
 } // namespace traceNames
 
 } // namespace android

--- a/app/src/main/native/cpp/frame_trace.hpp
+++ b/app/src/main/native/cpp/frame_trace.hpp
@@ -1,18 +1,22 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 
 #include <android/trace.h>
+#include <jni/jni.hpp>
+
+#include "util.hpp"
 
 namespace engine {
 namespace android {
 
-inline void traceBeginAsync(const char *name, int32_t cookie) {
-  ATrace_beginAsyncSection(name, cookie);
+inline void traceBeginAsync(const char *name, int32_t frameId) {
+  ATrace_beginAsyncSection(name, frameId);
 }
 
-inline void traceEndAsync(const char *name, int32_t cookie) {
-  ATrace_endAsyncSection(name, cookie);
+inline void traceEndAsync(const char *name, int32_t frameId) {
+  ATrace_endAsyncSection(name, frameId);
 }
 
 inline void traceSetCounter(const char *name, int64_t value) {
@@ -27,7 +31,6 @@ inline void traceEndSync() {
   ATrace_endSection();
 }
 
-// Stable section names — must match com.dz.camerafast.FrameTrace on the Kotlin side.
 namespace traceNames {
 constexpr const char *FRAME_TO_NATIVE_GL = "dz.frame_to_native.gl";
 constexpr const char *FRAME_TO_NATIVE_VK = "dz.frame_to_native.vk";
@@ -44,6 +47,35 @@ constexpr const char *DROPPED_FRAMES_VK = "dz.dropped_frames.vk";
 constexpr const char *FRAME_RENDER_GL = "dz.frame_render.gl";
 constexpr const char *FRAME_RENDER_VK = "dz.frame_render.vk";
 } // namespace traceNames
+
+class FrameTrace {
+
+public:
+  static constexpr auto Name() { return "com/dz/camerafast/FrameTrace"; }
+
+  static void registerNatives(JNIEnv &env) {
+    jni::RegisterNatives(env, *jni::Class<FrameTrace>::Find(env),
+            STATIC_METHOD(&FrameTrace::nextFrameId, "nextFrameId"),
+            STATIC_METHOD(&FrameTrace::traceBeginAsync, "traceBeginAsync"),
+            STATIC_METHOD(&FrameTrace::traceEndAsync, "traceEndAsync"),
+            STATIC_METHOD(&FrameTrace::frameE2EGlName, "frameE2EGlName"),
+            STATIC_METHOD(&FrameTrace::frameE2EVkName, "frameE2EVkName"),
+            STATIC_METHOD(&FrameTrace::frameToNativeGlName, "frameToNativeGlName"),
+            STATIC_METHOD(&FrameTrace::frameToNativeVkName, "frameToNativeVkName")
+    );
+  }
+
+  static jni::jint nextFrameId(jni::JNIEnv &env, jni::Class<FrameTrace> &);
+  static void traceBeginAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &, const jni::String &name, jni::jint frameId);
+  static void traceEndAsync(jni::JNIEnv &env, jni::Class<FrameTrace> &, const jni::String &name, jni::jint frameId);
+  static jni::Local<jni::String> frameE2EGlName(jni::JNIEnv &env, jni::Class<FrameTrace> &);
+  static jni::Local<jni::String> frameE2EVkName(jni::JNIEnv &env, jni::Class<FrameTrace> &);
+  static jni::Local<jni::String> frameToNativeGlName(jni::JNIEnv &env, jni::Class<FrameTrace> &);
+  static jni::Local<jni::String> frameToNativeVkName(jni::JNIEnv &env, jni::Class<FrameTrace> &);
+
+private:
+  static std::atomic<int32_t> frameCounter;
+};
 
 } // namespace android
 } // namespace engine

--- a/app/src/main/native/cpp/frame_trace.hpp
+++ b/app/src/main/native/cpp/frame_trace.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+
+namespace engine {
+namespace android {
+
+// Weak-linked so the shared library still loads on API 28 (project minSdk).
+// On API 29+ the dynamic linker resolves these to the real ATrace functions in libandroid.so.
+extern "C" {
+__attribute__((weak)) void ATrace_beginAsyncSection(const char *sectionName, int32_t cookie);
+__attribute__((weak)) void ATrace_endAsyncSection(const char *sectionName, int32_t cookie);
+}
+
+inline void traceBeginAsync(const char *name, int32_t cookie) {
+  if (&ATrace_beginAsyncSection) ATrace_beginAsyncSection(name, cookie);
+}
+
+inline void traceEndAsync(const char *name, int32_t cookie) {
+  if (&ATrace_endAsyncSection) ATrace_endAsyncSection(name, cookie);
+}
+
+// Stable section names — must match com.dz.camerafast.FrameTrace on the Kotlin side.
+namespace traceNames {
+constexpr const char *FRAME_TO_NATIVE_GL = "dz.frame_to_native.gl";
+constexpr const char *FRAME_TO_NATIVE_VK = "dz.frame_to_native.vk";
+constexpr const char *FRAME_NATIVE_PROC_GL = "dz.frame_native_proc.gl";
+constexpr const char *FRAME_NATIVE_PROC_VK = "dz.frame_native_proc.vk";
+constexpr const char *FRAME_TO_SCREEN_GL = "dz.frame_to_screen.gl";
+constexpr const char *FRAME_TO_SCREEN_VK = "dz.frame_to_screen.vk";
+constexpr const char *FRAME_E2E_GL = "dz.frame_e2e.gl";
+constexpr const char *FRAME_E2E_VK = "dz.frame_e2e.vk";
+} // namespace traceNames
+
+} // namespace android
+} // namespace engine

--- a/app/src/main/native/cpp/frame_trace.hpp
+++ b/app/src/main/native/cpp/frame_trace.hpp
@@ -2,22 +2,17 @@
 
 #include <cstdint>
 
+#include <android/trace.h>
+
 namespace engine {
 namespace android {
 
-// Weak-linked so the shared library still loads on API 28 (project minSdk).
-// On API 29+ the dynamic linker resolves these to the real ATrace functions in libandroid.so.
-extern "C" {
-__attribute__((weak)) void ATrace_beginAsyncSection(const char *sectionName, int32_t cookie);
-__attribute__((weak)) void ATrace_endAsyncSection(const char *sectionName, int32_t cookie);
-}
-
 inline void traceBeginAsync(const char *name, int32_t cookie) {
-  if (&ATrace_beginAsyncSection) ATrace_beginAsyncSection(name, cookie);
+  ATrace_beginAsyncSection(name, cookie);
 }
 
 inline void traceEndAsync(const char *name, int32_t cookie) {
-  if (&ATrace_endAsyncSection) ATrace_endAsyncSection(name, cookie);
+  ATrace_endAsyncSection(name, cookie);
 }
 
 // Stable section names — must match com.dz.camerafast.FrameTrace on the Kotlin side.

--- a/app/src/main/native/cpp/main.cpp
+++ b/app/src/main/native/cpp/main.cpp
@@ -1,11 +1,13 @@
 #include <jni/jni.hpp>
 
 #include "core_engine.hpp"
+#include "frame_trace.hpp"
 
 extern "C" JNIEXPORT jint
 
 JNICALL JNI_OnLoad(JavaVM *vm, void *) {
   jni::JNIEnv &env = jni::GetEnv(*vm);
   engine::android::CoreEngine::registerNatives(env);
+  engine::android::FrameTrace::registerNatives(env);
   return JNI_VERSION_1_6;
 }

--- a/app/src/main/native/cpp/opengl_renderer.cpp
+++ b/app/src/main/native/cpp/opengl_renderer.cpp
@@ -246,9 +246,11 @@ void OpenGLRenderer::destroyEgl() {
 }
 
 void OpenGLRenderer::renderImpl() {
+  traceBeginSync(traceNames::FRAME_RENDER_GL);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   // no actual camera drawing to do if first hardware buffer was not described and loaded to ext texture
   if (!hardwareBufferDescribed) {
+    traceEndSync();
     if (!eglSwapBuffers(eglDisplay, eglSurface)) {
       LOGE("eglSwapBuffers returned error %d", eglGetError());
     }
@@ -283,6 +285,7 @@ void OpenGLRenderer::renderImpl() {
   glDisableVertexAttribArray(1);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glUseProgram(0);
+  traceEndSync();
   if (!eglSwapBuffers(eglDisplay, eglSurface)) {
     LOGE("eglSwapBuffers returned error %d", eglGetError());
   } else {
@@ -300,8 +303,6 @@ void OpenGLRenderer::hwBufferToTexture(AHardwareBuffer *buffer) {
   if (!eglPrepared) {
     return;
   }
-  // first thing post another doFrame callback as we will need to render this texture
-  AChoreographer_postFrameCallback(aChoreographer, doFrame, this);
   static EGLint attrs[] = {EGL_NONE};
   EGLImageKHR image = eglCreateImageKHR(
           eglDisplay,

--- a/app/src/main/native/cpp/opengl_renderer.cpp
+++ b/app/src/main/native/cpp/opengl_renderer.cpp
@@ -290,10 +290,10 @@ void OpenGLRenderer::renderImpl() {
     LOGE("eglSwapBuffers returned error %d", eglGetError());
   } else {
     LOGI("Swapped buffers!");
-    if (pendingPresentCookie != -1) {
-      traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
-      traceEndAsync(frameE2ESectionName(), pendingPresentCookie);
-      pendingPresentCookie = -1;
+    if (pendingPresentFrameId != kNoPendingFrame) {
+      traceEndAsync(frameToScreenSectionName(), pendingPresentFrameId);
+      traceEndAsync(frameE2ESectionName(), pendingPresentFrameId);
+      pendingPresentFrameId = kNoPendingFrame;
     }
   }
 }

--- a/app/src/main/native/cpp/opengl_renderer.cpp
+++ b/app/src/main/native/cpp/opengl_renderer.cpp
@@ -252,6 +252,7 @@ void OpenGLRenderer::renderImpl() {
     if (!eglSwapBuffers(eglDisplay, eglSurface)) {
       LOGE("eglSwapBuffers returned error %d", eglGetError());
     }
+    // No camera frame was actually presented this tick — leave pendingPresentCookie alone.
     return;
   }
   glUseProgram(program);
@@ -287,6 +288,13 @@ void OpenGLRenderer::renderImpl() {
     LOGE("eglSwapBuffers returned error %d", eglGetError());
   } else {
     LOGI("Swapped buffers!");
+    // Close the per-frame ATrace slices for whichever camera frame's texture was just shown.
+    // Runs on the render thread, same thread that wrote pendingPresentCookie — no race.
+    if (pendingPresentCookie != -1) {
+      traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
+      traceEndAsync(frameE2ESectionName(), pendingPresentCookie);
+      pendingPresentCookie = -1;
+    }
   }
 }
 

--- a/app/src/main/native/cpp/opengl_renderer.cpp
+++ b/app/src/main/native/cpp/opengl_renderer.cpp
@@ -252,7 +252,6 @@ void OpenGLRenderer::renderImpl() {
     if (!eglSwapBuffers(eglDisplay, eglSurface)) {
       LOGE("eglSwapBuffers returned error %d", eglGetError());
     }
-    // No camera frame was actually presented this tick — leave pendingPresentCookie alone.
     return;
   }
   glUseProgram(program);
@@ -288,8 +287,6 @@ void OpenGLRenderer::renderImpl() {
     LOGE("eglSwapBuffers returned error %d", eglGetError());
   } else {
     LOGI("Swapped buffers!");
-    // Close the per-frame ATrace slices for whichever camera frame's texture was just shown.
-    // Runs on the render thread, same thread that wrote pendingPresentCookie — no race.
     if (pendingPresentCookie != -1) {
       traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
       traceEndAsync(frameE2ESectionName(), pendingPresentCookie);

--- a/app/src/main/native/cpp/opengl_renderer.hpp
+++ b/app/src/main/native/cpp/opengl_renderer.hpp
@@ -7,6 +7,7 @@
 #include <GLES2/gl2ext.h>
 
 #include "base_renderer.hpp"
+#include "frame_trace.hpp"
 
 namespace engine {
 namespace android {
@@ -17,6 +18,12 @@ protected:
     const char *renderingModeName() override {
         return (const char *) "OpenGL ES";
     }
+
+    const char *traceSuffix() const override { return "gl"; }
+    const char *frameToNativeSectionName() const override { return traceNames::FRAME_TO_NATIVE_GL; }
+    const char *frameNativeProcSectionName() const override { return traceNames::FRAME_NATIVE_PROC_GL; }
+    const char *frameToScreenSectionName() const override { return traceNames::FRAME_TO_SCREEN_GL; }
+    const char *frameE2ESectionName() const override { return traceNames::FRAME_E2E_GL; }
 
     bool onWindowCreated() override {
         return prepareEgl();

--- a/app/src/main/native/cpp/opengl_renderer.hpp
+++ b/app/src/main/native/cpp/opengl_renderer.hpp
@@ -19,11 +19,11 @@ protected:
         return (const char *) "OpenGL ES";
     }
 
-    const char *traceSuffix() const override { return "gl"; }
     const char *frameToNativeSectionName() const override { return traceNames::FRAME_TO_NATIVE_GL; }
     const char *frameNativeProcSectionName() const override { return traceNames::FRAME_NATIVE_PROC_GL; }
     const char *frameToScreenSectionName() const override { return traceNames::FRAME_TO_SCREEN_GL; }
     const char *frameE2ESectionName() const override { return traceNames::FRAME_E2E_GL; }
+    const char *droppedFramesCounterName() const override { return traceNames::DROPPED_FRAMES_GL; }
 
     bool onWindowCreated() override {
         return prepareEgl();

--- a/app/src/main/native/cpp/util.hpp
+++ b/app/src/main/native/cpp/util.hpp
@@ -3,6 +3,7 @@
 #include <android/log.h>
 
 #define METHOD(MethodPtr, name) jni::MakeNativePeerMethod<decltype(MethodPtr), (MethodPtr)>(name)
+#define STATIC_METHOD(MethodPtr, name) jni::MakeNativeMethod<decltype(MethodPtr), (MethodPtr)>(name)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR,"DzCoreNative",__VA_ARGS__)
 #define LOGW(...) __android_log_print(ANDROID_LOG_WARN,"DzCoreNative",__VA_ARGS__)
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO,"DzCoreNative",__VA_ARGS__)

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -815,10 +815,10 @@ void VulkanRenderer::renderImpl() {
     recreateSwapChain(0, 0);
   } else if (presentResult != VK_SUCCESS) {
     LOGE("vkQueuePresentKHR returned fatal %i", presentResult);
-  } else if (pendingPresentCookie != -1) {
-    traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
-    traceEndAsync(frameE2ESectionName(), pendingPresentCookie);
-    pendingPresentCookie = -1;
+  } else if (pendingPresentFrameId != kNoPendingFrame) {
+    traceEndAsync(frameToScreenSectionName(), pendingPresentFrameId);
+    traceEndAsync(frameE2ESectionName(), pendingPresentFrameId);
+    pendingPresentFrameId = kNoPendingFrame;
   }
 }
 

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -811,6 +811,12 @@ void VulkanRenderer::renderImpl() {
     recreateSwapChain(0, 0);
   } else if (presentResult != VK_SUCCESS) {
     LOGE("vkQueuePresentKHR returned fatal %i", presentResult);
+  } else if (pendingPresentCookie != -1) {
+    // Close the per-frame ATrace slices for whichever camera frame just made it onto the
+    // swapchain. Same render thread as the writer, no race.
+    traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
+    traceEndAsync(frameE2ESectionName(), pendingPresentCookie);
+    pendingPresentCookie = -1;
   }
 }
 

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -764,6 +764,7 @@ void VulkanRenderer::createOtherStaff() {
 }
 
 void VulkanRenderer::renderImpl() {
+  traceBeginSync(traceNames::FRAME_RENDER_VK);
   uint32_t nextIndex;
   // Get the framebuffer index we should draw in
   auto result = vkAcquireNextImageKHR(deviceInfo.device, swapchainInfo.swapchain,
@@ -772,11 +773,13 @@ void VulkanRenderer::renderImpl() {
   if (result == VK_ERROR_OUT_OF_DATE_KHR) {
     LOGW("vkAcquireNextImageKHR returned VK_ERROR_OUT_OF_DATE_KHR; recreating swapchain");
     recreateSwapChain(0, 0);
+    traceEndSync();
     return;
   }
   if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
     // nextIndex is undefined for non-success codes — dropping the frame.
     LOGE("vkAcquireNextImageKHR returned fatal %i; dropping frame", result);
+    traceEndSync();
     return;
   }
   CALL_VK(vkResetFences(deviceInfo.device, 1, &renderInfo.fence))
@@ -805,6 +808,7 @@ void VulkanRenderer::renderImpl() {
           .pImageIndices = &nextIndex,
           .pResults = nullptr,
   };
+  traceEndSync();
   const auto presentResult = vkQueuePresentKHR(deviceInfo.queue, &presentInfo);
   if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
     LOGW("vkQueuePresentKHR returned %i; recreating swapchain", presentResult);

--- a/app/src/main/native/cpp/vulkan_renderer.cpp
+++ b/app/src/main/native/cpp/vulkan_renderer.cpp
@@ -812,8 +812,6 @@ void VulkanRenderer::renderImpl() {
   } else if (presentResult != VK_SUCCESS) {
     LOGE("vkQueuePresentKHR returned fatal %i", presentResult);
   } else if (pendingPresentCookie != -1) {
-    // Close the per-frame ATrace slices for whichever camera frame just made it onto the
-    // swapchain. Same render thread as the writer, no race.
     traceEndAsync(frameToScreenSectionName(), pendingPresentCookie);
     traceEndAsync(frameE2ESectionName(), pendingPresentCookie);
     pendingPresentCookie = -1;

--- a/app/src/main/native/cpp/vulkan_renderer.hpp
+++ b/app/src/main/native/cpp/vulkan_renderer.hpp
@@ -17,11 +17,11 @@ protected:
     return (const char *) "Vulkan";
   }
 
-  const char *traceSuffix() const override { return "vk"; }
   const char *frameToNativeSectionName() const override { return traceNames::FRAME_TO_NATIVE_VK; }
   const char *frameNativeProcSectionName() const override { return traceNames::FRAME_NATIVE_PROC_VK; }
   const char *frameToScreenSectionName() const override { return traceNames::FRAME_TO_SCREEN_VK; }
   const char *frameE2ESectionName() const override { return traceNames::FRAME_E2E_VK; }
+  const char *droppedFramesCounterName() const override { return traceNames::DROPPED_FRAMES_VK; }
 
   bool onWindowCreated() override {
     if (!InitVulkan()) {

--- a/app/src/main/native/cpp/vulkan_renderer.hpp
+++ b/app/src/main/native/cpp/vulkan_renderer.hpp
@@ -4,6 +4,7 @@
 #include <shaderc/shaderc.hpp>
 
 #include "base_renderer.hpp"
+#include "frame_trace.hpp"
 #include "vulkan_wrapper.h"
 
 namespace engine {
@@ -15,6 +16,12 @@ protected:
   const char *renderingModeName() override {
     return (const char *) "Vulkan";
   }
+
+  const char *traceSuffix() const override { return "vk"; }
+  const char *frameToNativeSectionName() const override { return traceNames::FRAME_TO_NATIVE_VK; }
+  const char *frameNativeProcSectionName() const override { return traceNames::FRAME_NATIVE_PROC_VK; }
+  const char *frameToScreenSectionName() const override { return traceNames::FRAME_TO_SCREEN_VK; }
+  const char *frameE2ESectionName() const override { return traceNames::FRAME_E2E_VK; }
 
   bool onWindowCreated() override {
     if (!InitVulkan()) {

--- a/scripts/baseline-frame-latency.sh
+++ b/scripts/baseline-frame-latency.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Establish a frame-latency baseline: run scripts/measure-frame-latency.sh N
+# times (default 5) for D seconds each (default 10), force-stopping the app
+# between runs, then aggregate the per-run tables and print run-to-run
+# dispersion (mean / stdev / range / CV%) for every metric.
+#
+# Usage:
+#   scripts/baseline-frame-latency.sh             # 5 runs × 10 s
+#   scripts/baseline-frame-latency.sh 5 10        # explicit
+#
+# Output also written to .cache/frame-latency/baseline.{txt,json} so CI (or
+# a future PR-vs-main diff step) can ingest the numbers without re-parsing.
+
+set -euo pipefail
+
+RUNS="${1:-5}"
+DURATION="${2:-10}"
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]] || ! [[ "$DURATION" =~ ^[1-9][0-9]*$ ]]; then
+  echo "usage: $0 [runs] [seconds]   (both positive integers)" >&2
+  exit 2
+fi
+
+PKG="com.dz.camerafast"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CACHE_DIR="$ROOT/.cache/frame-latency"
+RUNS_DIR="$CACHE_DIR/runs"
+mkdir -p "$RUNS_DIR"
+rm -f "$RUNS_DIR"/run_*.txt
+
+echo "Running ${RUNS} × ${DURATION}s on attached device, force-stopping ${PKG} between runs."
+echo
+
+for i in $(seq 1 "$RUNS"); do
+  echo "=========================== RUN $i / $RUNS ==========================="
+  "$SCRIPT_DIR/measure-frame-latency.sh" "$DURATION" | tee "$RUNS_DIR/run_$i.txt"
+  adb shell am force-stop "$PKG" >/dev/null || true
+  echo
+  # Brief idle so the next run's warm-up isn't competing with the previous teardown.
+  [[ "$i" -lt "$RUNS" ]] && sleep 2
+done
+
+BASELINE_TXT="$CACHE_DIR/baseline.txt"
+BASELINE_JSON="$CACHE_DIR/baseline.json"
+
+python3 - "$RUNS_DIR" "$RUNS" "$DURATION" "$BASELINE_TXT" "$BASELINE_JSON" <<'PY'
+import collections, json, re, statistics, sys, glob, os
+
+runs_dir, runs, duration, out_txt, out_json = sys.argv[1:6]
+runs, duration = int(runs), int(duration)
+
+data = collections.defaultdict(list)
+stages = []
+metrics = ["n", "avg", "p50", "p90", "p99", "max"]
+line_re = re.compile(
+    r"^(dz\.frame_\S+)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)"
+)
+
+for path in sorted(glob.glob(os.path.join(runs_dir, "run_*.txt"))):
+    with open(path) as f:
+        for line in f:
+            m = line_re.match(line)
+            if not m: continue
+            stage = m.group(1)
+            if stage not in stages: stages.append(stage)
+            data[(stage, "n")].append(int(m.group(2)))
+            for k, j in zip(metrics[1:], range(3, 8)):
+                data[(stage, k)].append(float(m.group(j)))
+
+# Build text table.
+lines = []
+hdr = f"{'stage':<28} {'metric':<5} {'mean':>7} {'stdev':>7} {'range':>7} {'CV%':>6}   raw"
+lines.append(hdr)
+lines.append("-" * len(hdr))
+for stage in sorted(stages):
+    for metric in metrics[1:]:
+        vals = data[(stage, metric)]
+        mu = statistics.mean(vals)
+        sd = statistics.stdev(vals) if len(vals) > 1 else 0.0
+        rg = max(vals) - min(vals)
+        cv = (sd / mu * 100) if mu > 0 else 0.0
+        raw = " ".join(f"{v:6.2f}" for v in vals)
+        lines.append(f"{stage:<28} {metric:<5} {mu:7.2f} {sd:7.2f} {rg:7.2f} {cv:5.1f}%  {raw}")
+    lines.append("")
+lines.append(f"{'stage':<28} {'n_mean':>7} {'n_stdev':>8} {'n_range':>8}    raw")
+lines.append("-" * 70)
+for stage in sorted(stages):
+    vals = data[(stage, "n")]
+    mu = statistics.mean(vals); sd = statistics.stdev(vals) if len(vals) > 1 else 0.0
+    raw = " ".join(f"{v:4d}" for v in vals)
+    lines.append(f"{stage:<28} {mu:7.1f} {sd:8.2f} {max(vals)-min(vals):8d}    {raw}")
+
+text = "\n".join(lines)
+print()
+print(text)
+with open(out_txt, "w") as f: f.write(text + "\n")
+
+# Machine-readable form for future PR-vs-main diff jobs.
+out = {
+    "runs": runs,
+    "duration_s": duration,
+    "stages": {},
+}
+for stage in sorted(stages):
+    out["stages"][stage] = {}
+    for metric in metrics:
+        vals = data[(stage, metric)]
+        mu = statistics.mean(vals)
+        sd = statistics.stdev(vals) if len(vals) > 1 else 0.0
+        out["stages"][stage][metric] = {
+            "mean": round(mu, 3),
+            "stdev": round(sd, 3),
+            "cv_pct": round((sd / mu * 100) if mu > 0 else 0.0, 2),
+            "values": vals,
+        }
+with open(out_json, "w") as f: json.dump(out, f, indent=2)
+
+print()
+print(f"baseline saved: {out_txt}")
+print(f"               {out_json}")
+PY

--- a/scripts/measure-frame-latency.sh
+++ b/scripts/measure-frame-latency.sh
@@ -8,9 +8,10 @@
 #   scripts/measure-frame-latency.sh [seconds]      (default: 10)
 #
 # Requires: adb on PATH, python3, curl (only the first time, to fetch
-# Perfetto's trace_processor). Device must already have the debug APK
-# installed; run `./gradlew :app:installDebug -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi)`
-# first if needed.
+# Perfetto's trace_processor). Device must already have the release APK
+# installed; run `./gradlew :app:installRelease -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi)`
+# first if needed. Release is signed with the debug keystore and declares
+# <profileable android:shell="true"/> so Perfetto can attach.
 
 set -euo pipefail
 
@@ -56,8 +57,8 @@ echo "Device: $model (serial=$serial, sdk=$sdk, abi=$abi)"
 # 2. APK installed?
 if ! adb shell cmd package list packages -3 | tr -d '\r' | grep -qx "package:${PKG}"; then
   echo "error: $PKG is not installed on the device." >&2
-  echo "Install it with:" >&2
-  echo "  ./gradlew :app:installDebug -Pandroid.injected.build.abi=$abi" >&2
+  echo "Install the release variant (debug NDK is slower; release is signed with the debug key):" >&2
+  echo "  ./gradlew :app:installRelease -Pandroid.injected.build.abi=$abi" >&2
   exit 1
 fi
 

--- a/scripts/measure-frame-latency.sh
+++ b/scripts/measure-frame-latency.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Launch CameraActivity, capture a Perfetto trace for N seconds, and print
+# avg/p50/p90/p99/max for every dz.frame_*.{gl,vk} async slice emitted by the
+# instrumentation in app/src/main/{java,native/cpp}/.
+#
+# Usage:
+#   scripts/measure-frame-latency.sh [seconds]      (default: 10)
+#
+# Requires: adb on PATH, python3, curl (only the first time, to fetch
+# Perfetto's trace_processor). Device must already have the debug APK
+# installed; run `./gradlew :app:installDebug -Pandroid.injected.build.abi=$(adb shell getprop ro.product.cpu.abi)`
+# first if needed.
+
+set -euo pipefail
+
+DURATION="${1:-10}"
+if ! [[ "$DURATION" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: duration must be a positive integer (seconds); got '$DURATION'" >&2
+  exit 2
+fi
+
+PKG="com.dz.camerafast"
+ACTIVITY="${PKG}/.CameraActivity"
+
+# Cache trace_processor + intermediate artifacts under .cache/ so we don't
+# repeatedly download the binary or collide with /tmp on shared machines.
+CACHE_DIR="$(cd "$(dirname "$0")/.." && pwd)/.cache/frame-latency"
+mkdir -p "$CACHE_DIR"
+TP="$CACHE_DIR/trace_processor"
+TRACE="$CACHE_DIR/trace.pftrace"
+DURATIONS_CSV="$CACHE_DIR/durations.csv"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "error: $1 not on PATH" >&2; exit 2; }; }
+need adb
+need python3
+
+# 1. Preflight: exactly one device
+devices="$(adb devices | awk 'NR>1 && $2=="device" {print $1}')"
+count="$(echo "$devices" | grep -c . || true)"
+if [[ "$count" -eq 0 ]]; then
+  echo "error: no adb device in 'device' state. Plug a device in and authorize ADB." >&2
+  exit 1
+elif [[ "$count" -gt 1 ]]; then
+  echo "error: multiple adb devices attached:" >&2
+  echo "$devices" >&2
+  echo "Pick one with: export ANDROID_SERIAL=<serial>" >&2
+  exit 1
+fi
+serial="$devices"
+abi="$(adb shell getprop ro.product.cpu.abi | tr -d '\r')"
+sdk="$(adb shell getprop ro.build.version.sdk | tr -d '\r')"
+model="$(adb shell getprop ro.product.model | tr -d '\r')"
+echo "Device: $model (serial=$serial, sdk=$sdk, abi=$abi)"
+
+# 2. APK installed?
+if ! adb shell cmd package list packages -3 | tr -d '\r' | grep -qx "package:${PKG}"; then
+  echo "error: $PKG is not installed on the device." >&2
+  echo "Install it with:" >&2
+  echo "  ./gradlew :app:installDebug -Pandroid.injected.build.abi=$abi" >&2
+  exit 1
+fi
+
+# 3. Trace processor: download once if missing.
+if [[ ! -x "$TP" ]]; then
+  need curl
+  echo "Downloading trace_processor into $TP ..."
+  curl -sSL https://get.perfetto.dev/trace_processor -o "$TP"
+  chmod +x "$TP"
+fi
+
+# 4. Launch the app fresh (force-stop so prior config doesn't carry over).
+adb shell pm grant "$PKG" android.permission.CAMERA
+adb shell am force-stop "$PKG"
+adb shell am start -n "$ACTIVITY" >/dev/null
+# Give camera + GPU contexts a moment to initialize before we start measuring.
+sleep 2
+
+# 5. Capture. -a <pkg> is required for app-tag atrace sections to actually land in the trace.
+DEVICE_TRACE="/data/misc/perfetto-traces/dz-frame-latency.pftrace"
+echo "Capturing ${DURATION}s of Perfetto trace ..."
+adb shell "perfetto -o ${DEVICE_TRACE} -t ${DURATION}s -b 32mb -a ${PKG} gfx view app sched" \
+  | grep -E "Wrote|Connected" || true
+adb pull "$DEVICE_TRACE" "$TRACE" >/dev/null
+adb shell rm "$DEVICE_TRACE" 2>/dev/null || true
+echo "Pulled trace -> $TRACE ($(du -h "$TRACE" | cut -f1))"
+
+# 6. Extract durations for our slices into a CSV the python step can consume.
+"$TP" query "$TRACE" \
+  "SELECT name, dur FROM slice WHERE name LIKE 'dz.frame_%' AND dur >= 0" \
+  > "$DURATIONS_CSV" 2>/dev/null
+
+rows="$(($(wc -l < "$DURATIONS_CSV") - 1))"
+if [[ "$rows" -le 0 ]]; then
+  echo "error: no dz.frame_* slices captured. Ruled-out causes:" >&2
+  echo "  - APK out of date (rebuild with installDebug)." >&2
+  echo "  - perfetto was not invoked with -a $PKG (already handled above)." >&2
+  echo "  - Camera permission denied / activity did not actually run." >&2
+  exit 1
+fi
+echo "Captured $rows slices total."
+echo
+
+# 7. Aggregate + print.
+python3 - "$DURATIONS_CSV" "$DURATION" <<'PY'
+import csv, collections, sys
+
+path, duration_s = sys.argv[1], int(sys.argv[2])
+buckets = collections.defaultdict(list)
+with open(path) as f:
+    for row in csv.DictReader(f):
+        buckets[row["name"]].append(int(row["dur"]))
+
+def pct(values, p):
+    s = sorted(values)
+    k = (len(s) - 1) * p / 100
+    lo = int(k); hi = min(lo + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+ms = lambda ns: f"{ns/1e6:7.2f}"
+hdr = f"{'stage':<28} {'n':>4} {'avg':>7} {'p50':>7} {'p90':>7} {'p99':>7} {'max':>7}  (ms)"
+print(hdr)
+print("-" * len(hdr))
+for name in sorted(buckets):
+    v = buckets[name]
+    avg = sum(v) / len(v)
+    print(f"{name:<28} {len(v):>4} {ms(avg)} {ms(pct(v,50))} {ms(pct(v,90))} {ms(pct(v,99))} {ms(max(v))}")
+PY
+
+echo
+echo "Re-query the trace at $TRACE with: $TP query $TRACE \"<sql>\""


### PR DESCRIPTION
## Summary

Instruments every camera frame with Perfetto ATrace sections so PR-level latency baselines become possible, plus the tooling to capture/aggregate them. Verified on SM-F936B / Android 16 / arm64-v8a.

## What's added

**Instrumentation (`app/src/main/native/cpp/frame_trace.{hpp,cpp}` + `FrameTrace.kt`)**
- 4 async slices per camera frame, per renderer: `dz.frame_to_native.<gl|vk>`, `dz.frame_native_proc.<gl|vk>`, `dz.frame_to_screen.<gl|vk>`, `dz.frame_e2e.<gl|vk>`.
- 1 sync sub-section inside `renderImpl`: `dz.frame_render.<gl|vk>` — ends *before* swap/present, so `frame_to_screen − frame_render` isolates vsync wait.
- 1 counter track per renderer: `dz.dropped_frames.<gl|vk>` — authoritative drop count.
- Single source of truth for section names in `frame_trace.hpp`; Kotlin reads them via JNI at class-load. JNI binding follows the same `jni.hpp` style as `CoreEngine` (new `STATIC_METHOD` macro paralleling `METHOD`).

**Build/manifest**
- `minSdk` 28 → 29 (ATrace async APIs are 29+; weak-linking dropped).
- `compileSdk`/`targetSdk` 34 → 35 (edge-to-edge prerequisite).
- `<profileable android:shell="true"/>` in manifest; `signingConfig signingConfigs.debug` on the release buildType — `installRelease` works locally and Perfetto can attach without `debuggable`.
- Edge-to-edge UI: `enableEdgeToEdge()` + per-component insets so previews extend behind transparent system bars.

**Tooling**
- `scripts/measure-frame-latency.sh [seconds]` — one-shot capture + per-stage `n/avg/p50/p90/p99/max` table. Auto-downloads Perfetto's `trace_processor` to `.cache/frame-latency/`.
- `scripts/baseline-frame-latency.sh [runs] [seconds]` (default 5×10s) — multi-run dispersion (mean / stdev / range / CV%), saves human + JSON forms for future CI diff.
- New skills: `/verify-on-device` (build-install-screenshot loop), `/frame-latency-baseline` (the baseline runner with interpretation guidance).
- Submodule: `vendor/android-skills` (Google's AI-optimized SKILL.md collection).

**Docs**
- `CLAUDE.md` at repo root: architecture/data flow, instrumentation contract, build gotchas, baseline numbers + per-metric gating recommendation, "code style: no verbose comments" rule.

## Bugs fixed along the way

- **Double Choreographer schedule on OpenGL** — `OpenGLRenderer::hwBufferToTexture` was posting a frame callback that `BaseRenderer::processCameraFrame` already posts; GL was rendering ~2× per camera frame. Removed.
- **Orphan async slices on dropped frames** — superseded frames' `frame_e2e` / `frame_to_screen` were left dangling and rendered as infinite-length in Perfetto UI. Now closed at supersede; the `dropped_frames` counter is the authoritative drop count.

## Baseline (5 × 10s on release, SM-F936B)

| Metric | mean | CV% |
|---|---:|---:|
| `frame_e2e.gl.avg` | 13.25 ms | 1.8% |
| `frame_e2e.gl.p90` | 20.72 ms | 1.4% |
| `frame_e2e.vk.avg` | 14.91 ms | 1.3% |
| `frame_e2e.vk.p90` | 22.48 ms | 1.0% |
| `frame_render.gl.avg` | 0.57 ms | 6.4% |
| `frame_render.vk.avg` | 1.76 ms | 5.0% |

Full table + gating recommendation per metric in `CLAUDE.md`. JSON for future CI diff at `.cache/frame-latency/baseline.json`.

<img width="1679" height="558" alt="image" src="https://github.com/user-attachments/assets/fda375c2-b179-4f36-a6ad-11fc8bf86ae5" />


## Not in this PR

Macrobenchmark module wrapping the same capture + GHA / Firebase-Test-Lab gate against `baseline.json` — separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)